### PR TITLE
Added checks for minimums

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -207,13 +207,13 @@ int verify_args(struct ntttcp_test *test)
 	}
 
 	if (test->conn_per_thread < 1) {
-		PRINT_INFO("You need at least one connection per thread. Using one connection per thread.");
-		test->conn_per_thread = MAX_CONNECTIONS_PER_THREAD;
+		PRINT_INFO("invalid connections-per-server-port provided. use 1");
+		test->conn_per_thread = 1;
 	}
 
 	if (test->parallel < 1) {
-		PRINT_INFO("You need at least one port listening on the receiver. Using one port listening on the receiver.");
-		test->parallel = MAX_NUM_THREADS;
+		PRINT_INFO("invalid number-of-server-ports provided. use 1");
+		test->parallel = 1;
 	}	
 	
 	if (test->domain == AF_INET6 && strcmp( test->bind_address, "0.0.0.0")== 0 )

--- a/src/util.c
+++ b/src/util.c
@@ -206,6 +206,16 @@ int verify_args(struct ntttcp_test *test)
 		test->parallel = MAX_NUM_THREADS;
 	}
 
+	if (test->conn_per_thread < 1) {
+		PRINT_INFO("You need at least one connection per thread. Using one connection per thread.");
+		test->conn_per_thread = MAX_CONNECTIONS_PER_THREAD;
+	}
+
+	if (test->parallel < 1) {
+		PRINT_INFO("You need at least one port listening on the receiver. Using one port listening on the receiver.");
+		test->parallel = MAX_NUM_THREADS;
+	}	
+	
 	if (test->domain == AF_INET6 && strcmp( test->bind_address, "0.0.0.0")== 0 )
 		test->bind_address = "::";
 


### PR DESCRIPTION
Added checks for minimum=1 on: 

- Number of ports listening on receiver side (-P)    
- [sender only] number of connections per receiver port    [default: 4]  [max: 512] (-n)    
- <mapping>  for the purpose of compatible with Windows ntttcp usage Where a mapping is a **NumberOfReceiverPorts**,Processor,BindingIPAddress set (-m)

