### PR TITLE
Alpine Linux compatibility

### DIFF
--- a/src/ntttcp.h
+++ b/src/ntttcp.h
@@ -1,4 +1,3 @@
-
 // ----------------------------------------------------------------------------------
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.

--- a/src/ntttcp.h
+++ b/src/ntttcp.h
@@ -1,3 +1,4 @@
+
 // ----------------------------------------------------------------------------------
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -11,6 +12,7 @@
 #include <inttypes.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include "const.h"
 #include "logger.h"
 


### PR DESCRIPTION
Unless we explicitly include types.h, ntttcp does not compile under Alpine Linux (and maybe other libmusl based systems).