### PR TITLE
Remove dead code in create_receiver_sync_socket()

### DIFF
--- a/src/endpointsync.c
+++ b/src/endpointsync.c
@@ -398,11 +398,6 @@ void *create_receiver_sync_socket( void *ptr )
 
 					case (int)'L':  //the last client joined, and request to start the test
 						if (tep->test->multi_clients_mode == true) {
-							if (tep->num_remote_endpoints >= MAX_REMOTE_ENDPOINTS) {
-								/* the last seat has been taken; too many client! */
-								answer_to_send = (int)'E'; //'E': ERROR
-							}
-
 							/* firstly, add this client into the client collection */
 							tep->remote_endpoints[ tep->num_remote_endpoints++ ] = current_fd;
 


### PR DESCRIPTION
Hello.

I think, the if conditional statement in src/endpointsync.c on line 401 is useless.

The ```answer_to_send``` variable receives a new value at 410 line.

what do you think?

Thanks.
