### PR TITLE
tcpstream.c: Close fd after an error

### DIFF
--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -459,6 +459,7 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 						else {
 							ASPRINTF(&log, "error to accept new connections. errno = %d", errno)
 							PRINT_ERR_FREE(log);
+							close (ss->listener);
 							break;
 						}
 					}


### PR DESCRIPTION
Otherwise, for me, it is getting into infinite loop with following continuous prints:

03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
03:53:33 ERR : error to accept new connections. errno = 24
