### PR TITLE
Allow cross-compilation by not forcing CC=gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,6 @@
+ifndef CC
 CC=gcc
+endif
 ifeq ($(DEBUG), 1)
 CFLAGS=-Wall -W -O0 -ggdb3 -fno-omit-frame-pointer
 else


### PR DESCRIPTION
Only set CC=gcc if CC is undefined