### PR TITLE
Fix inconsistency in data statistics

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,6 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 	uint conns_created = 0, conns_total = 0;
 	struct ntttcp_stream_client *cs;
 	int rc, reply_received;
-	void *p_retval;
 	struct timeval start_time, now;
 	long int conns_creation_time_usec = 0;
 
@@ -101,6 +100,8 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 				ASPRINTF(&log, "pthread_create() create thread failed. errno = %d", errno);
 				PRINT_ERR_FREE(log);
 				err_code = ERROR_PTHREAD_CREATE;
+				/* Set self tid to mark current thread as unused */
+				tep->threads[threads_created] = pthread_self();
 				continue;
 			}
 			else{
@@ -169,13 +170,6 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 	 * (calling wait_light_off() inside of below
 	 */
 	run_ntttcp_throughput_management(tep);
-
-	for (n = 0; n < threads_created; n++) {
-		if (pthread_join(tep->threads[n], &p_retval) !=0 ) {
-			PRINT_ERR("sender: error when pthread_join");
-			continue;
-		}
-	}
 
 	process_test_results(tep);
 	print_test_results(tep);

--- a/src/throughputmanagement.c
+++ b/src/throughputmanagement.c
@@ -179,6 +179,21 @@ void run_ntttcp_throughput_management(struct ntttcp_test_endpoint *tep)
 			break;
 	}
 
+	/* Wait for stream processing completion before capturing statistics */
+	if (tep->endpoint_role == ROLE_SENDER) {
+		for (n = 0; n < tep->total_threads; n++) {
+			void *p_retval;
+
+			if (pthread_equal(tep->threads[n], pthread_self())) {
+				continue;
+			}
+			if (pthread_join(tep->threads[n], &p_retval) !=0 ) {
+				PRINT_ERR("sender: error when pthread_join");
+				continue;
+			}
+		}
+	}
+
 	/* calculate the end resource usage */
 	get_cpu_usage( tep->results->final_cpu_usage );
 	get_cpu_usage_from_proc_stat( tep->results->final_cpu_ps );


### PR DESCRIPTION
Issue:
Main thread on client side can start capturing statistics
in run_ntttcp_throughput_management() before worker finished sending
data in run_ntttcp_sender_tcp_stream().
As a result 'total bytes' on sender and receiver can report different
numbers.

Fix:
This change allows to gather application results on client side
after data send is finished.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>