### PR TITLE
Add support for generating install target for make

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,8 @@ util.c)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -O2 -fno-strict-aliasing")
 
+include(GNUInstallDirs)
+
 add_executable(${PROJECT_NAME} ${SRC_NTTTCP})
 target_link_libraries(${PROJECT_NAME} pthread)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,3 +19,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -W -O2 -fno-strict-aliasing")
 
 add_executable(${PROJECT_NAME} ${SRC_NTTTCP})
 target_link_libraries(${PROJECT_NAME} pthread)
+
+install(TARGETS ntttcp
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
cmake has support for generating the install target for the makefile.

Adding command to generate it.