### PR TITLE
Several performance optimizations for small I/O.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/*.o
+src/ntttcp

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,8 +37,8 @@ main.o: main.c
 
 .PHONY: clean
 clean:
-	rm -rf /usr/bin/$(OUT)
-	rm -rf *.o $(OUT)
+	rm -f *.o $(OUT)
+	rm -f /usr/bin/$(OUT)
 
 .PHONY: install
 install:

--- a/src/multithreading.c
+++ b/src/multithreading.c
@@ -45,18 +45,9 @@ void wait_light_off( void )
 	pthread_mutex_unlock( &light_mutex );
 }
 
-int is_light_turned_on( bool ignore )
+int is_light_turned_on( void )
 {
-	int temp;
-
-	if (ignore)
-		return true;
-
-	pthread_mutex_lock( &light_mutex );
-	temp = run_light;
-	pthread_mutex_unlock( &light_mutex );
-
-	return temp;
+	return run_light;
 }
 
 /************************************************************/
@@ -68,7 +59,7 @@ void sig_handler(int signo)
 	if (signo == SIGINT) {
 		PRINT_INFO("Interrupted by Ctrl+C");
 
-		if (is_light_turned_on(false))
+		if (is_light_turned_on())
 			turn_off_light();
 		else
 			exit (1);

--- a/src/multithreading.h
+++ b/src/multithreading.h
@@ -19,7 +19,7 @@ void turn_on_light( void );
 void turn_off_light( void );
 void wait_light_on( void );
 void wait_light_off( void );
-int is_light_turned_on( bool ignore );
+int is_light_turned_on( void );
 
 void sig_handler(int signo);
 void run_test_timer(int duration);

--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -521,7 +521,6 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 			/* handle data from an EXISTING client */
 			else {
 				for (int max_io = 0; max_io < MAX_IO_PER_POLL; max_io++) {
-					bzero(buffer, ss->recv_buf_size);
 					bytes_to_be_read = ss->is_sync_thread ? 1 : ss->recv_buf_size;
 
 					/* got error or connection closed by client */
@@ -657,7 +656,6 @@ int ntttcp_server_select(struct ntttcp_stream_server *ss)
 			/* handle data from an EXISTING client */
 			else{
 				for (int max_io = 0; max_io < MAX_IO_PER_POLL; max_io++) {
-					bzero(buffer, ss->recv_buf_size);
 					bytes_to_be_read = ss->is_sync_thread ? 1 : ss->recv_buf_size;
 
 					/* got error or connection closed by client */

--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -543,7 +543,7 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 						break;
 					}
 					/* report how many bytes received */
-					else if (nbytes > 0) {
+					else {
 						__sync_fetch_and_add(&(ss->total_bytes_transferred), nbytes);
 					}
 				}

--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -507,15 +507,15 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 						PRINT_DBG_FREE(log);
 					}
 
-					//if there is no synch thread, if any new connection coming, indicates ss started
-					if ( ss->no_synch )
-						turn_on_light();
-					//else, leave the sync thread to fire the trigger
-
 					event.data.fd = newfd;
 					event.events = EPOLLIN;
 					if (epoll_ctl (efd, EPOLL_CTL_ADD, newfd, &event) != 0)
 						PRINT_ERR("epoll_ctl failed");
+
+					//if there is no synch thread, if any new connection coming, indicates ss started
+					if ( ss->no_synch )
+						turn_on_light();
+					//else, leave the sync thread to fire the trigger
 				}
 			}
 			/* handle data from an EXISTING client */

--- a/src/tcpstream.h
+++ b/src/tcpstream.h
@@ -14,8 +14,8 @@
 #include "util.h"
 #include "multithreading.h"
 
-int n_read(int fd, char *buffer, size_t total);
-int n_write(int fd, const char *buffer, size_t total);
+int n_recv(int fd, char *buffer, size_t total);
+int n_send(int fd, const char *buffer, size_t total);
 
 void *run_ntttcp_sender_tcp_stream( void *ptr );
 

--- a/src/throughputmanagement.c
+++ b/src/throughputmanagement.c
@@ -117,7 +117,7 @@ void run_ntttcp_throughput_management(struct ntttcp_test_endpoint *tep)
 			elapsed_sec += last_checkpoint.interval_sec;
 
 			/* if test was interrupted by CTRL + C */
-			if (!is_light_turned_on(tep->test->duration == 0)) {
+			if (!is_light_turned_on()) {
 				PRINT_INFO("Test was interrupted.");
 				goto END;
 			}
@@ -155,7 +155,7 @@ void run_ntttcp_throughput_management(struct ntttcp_test_endpoint *tep)
 	tep->results->init_rx_packets = get_single_value_from_os_file(tep->test->show_interface_packets, "rx");
 	tep->results->init_interrupts = get_interrupts_from_proc_by_dev(tep->test->show_dev_interrupts);
 
-	while(is_light_turned_on(tep->test->duration == 0)) {
+	while(is_light_turned_on()) {
 		/* Wait 500 micro-seconds. We don't want to pull the status too often.
 		 * But, we also don't want to wait too long time;
 		 * otherwise, in the case of CTRL+C, the test streams have been stopped by CTRL+C (then light is turned off), but we are still waiting here

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -85,6 +85,17 @@ void *run_ntttcp_sender_udp4_stream( struct ntttcp_stream_client * sc )
 	if (sc->socket_fq_rate_limit_bytes != 0)
 		enable_fq_rate_limit(sc, sockfd);
 
+	if (connect(sockfd, &serv_addr, sa_size) == -1) {
+		ASPRINTF(&log,
+			 "failed to connect socket[%d] to remote: [%s:%d]. errno = %d.",
+			 sockfd,
+			 sc->bind_address,
+			 sc->server_port,
+			 errno);
+		PRINT_ERR(log);
+		continue;
+	}
+
 	ASPRINTF(&log, "Running UDP stream: local:%d [socket:%d] --> %s:%d",
 		 ntohs(((struct sockaddr_in *)&local_addr)->sin_port),
 		 sockfd,
@@ -110,7 +121,7 @@ void *run_ntttcp_sender_udp4_stream( struct ntttcp_stream_client * sc )
 	}
 
 	memset(buffer, 'B', sc->send_buf_size * sizeof(char));
-	while (is_light_turned_on(sc->continuous_mode)) {
+	while (is_light_turned_on()) {
 		if (sc->hold_on)
 			continue;
 
@@ -120,7 +131,7 @@ void *run_ntttcp_sender_udp4_stream( struct ntttcp_stream_client * sc )
 			if (sockfd < 0)
 				continue;
 
-			n = sendto(sockfd, buffer, sc->send_buf_size, 0, (struct sockaddr *)&serv_addr, sa_size);
+			n = send(sockfd, buffer, sc->send_buf_size, 0);
 			if (n < 0) {
 	//			PRINT_ERR("cannot write data to a socket");
 	//			printf("error: %d \n", errno);

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -279,7 +279,6 @@ void *run_ntttcp_receiver_udp4_stream( struct ntttcp_stream_server * ss )
 		    ss->endpoint->state == TEST_FINISHED)
 			break;
 
-		bzero(buffer, ss->recv_buf_size);
 		nbytes = recvfrom(sockfd, buffer, ss->recv_buf_size, 0, (struct sockaddr *)&remote_addr, &addrlen);
 		if (nbytes > 0) {
 			__sync_fetch_and_add(&(ss->total_bytes_transferred), nbytes);


### PR DESCRIPTION
1. Drain TCP receives until EAGAIN (i.e. EWOULDBLOCK) rather
   than continuously polling. Limit the number of consecutive
   receives for some rudimentary fairness across connections.

2. Don't acquire a mutex in the IO loop (is_light_turned_on())
   and instead simply examine the boolean variable.

3. Use connected UDP sockets for sends (similar to Windows NTTTcp.)

4. Use send/recv rather than read/write.

A couple minor fixes to the project itself.

1. 'make clean' makes a best effort without root access.

2. Add a .gitignore.