### PR TITLE
Do not print escape sequences to stdout if terminal isn't a TTY

### DIFF
--- a/src/throughputmanagement.c
+++ b/src/throughputmanagement.c
@@ -5,6 +5,7 @@
 // ----------------------------------------------------------------------------------
 
 #include "throughputmanagement.h"
+#include "util.h"
 
 void check_bandwidth_limit(struct ntttcp_test_endpoint *tep)
 {
@@ -62,9 +63,9 @@ struct report_segment report_real_time_throughput(struct ntttcp_test_endpoint *t
 	total_bytes = this_total_bytes - last_total_bytes;
 
 	if (!tep->test->quiet) {
-		printf("%c[2K", 27); /* cleanup current line */
 		char *throughput = format_throughput(total_bytes, test_time);
-		printf("%s: %s\r", "Real-time throughput", throughput);
+		char line_end = clear_current_line();
+		printf("%s: %s%c", "Real-time throughput", throughput, line_end);
 		fflush(stdout);
 		free(throughput);
 	}

--- a/src/util.h
+++ b/src/util.h
@@ -108,3 +108,5 @@ int set_socket_non_blocking(int fd);
 void enable_fq_rate_limit(struct ntttcp_stream_client *sc, int sockfd);
 bool check_resource_limit(struct ntttcp_test *test);
 bool check_is_ip_addr_valid_local(int ss_family, char *ip_to_check);
+
+char clear_current_line(void);


### PR DESCRIPTION
When redirecting the output to a file, the real-time throughput information
will be printed with escape sequences to clear the current line.  This will
make it difficult to look at the results later and see if the throughput
changed during testing.

Print the escape sequence only if the terminal isn't a TTY, or if the $TERM
environment variable isn't set to "dumb".

CC @harz566