### PR TITLE
Leemich

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -462,11 +462,11 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	fprintf(logfile, "	<cycles_per_byte metric=\"cycles/byte\">%.2f</cycles_per_byte>\n", tepr->cycles_per_byte);
 	fprintf(logfile, "	<cpu_busy_all metric=\"%%\">%.2f</cpu_busy_all>\n", tepr->cpu_busy_percent * 100);
 	fprintf(logfile, "	<io>%u</io>\n", 0);
-
-	if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
-		fprintf(logfile, "	<tcp_average_rtt metric=\"us\">%u</tcp_average_rtt>\n", tepr->average_rtt);
+	if (test->verbose){
+		if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
+			fprintf(logfile, "	<tcp_average_rtt metric=\"us\">%u</tcp_average_rtt>\n", tepr->average_rtt);
+		}
 	}
-
 	count = execute_system_cmd_by_process("uname -a", "r", &os_info);
 	if (os_info) {
 		escape_char_for_xml(os_info, os_info_escaped);


### PR DESCRIPTION
Changed xml logging to have output parity with txt logging. Below are links to txt and xml output from a sample run between two Ubuntu machines with the following commands: 
`ntttcp -s10.0.0.11 -L  -n 2 -l 3 -t 300 -b 124k --show-dev-interrupts mlx -W 5`
`ntttcp -r -D -M 1 -t 300 -b 64k -P 16 -W 5 --show-dev-interrupts mlx`

[ntttcp-for-linux-logs.xml](https://microsoft.sharepoint.com/:u:/t/AzurePerfInvestigations/EZ2rLFMj0UZFrfJZovl58yQBIBGVQkDGbOdBF5_LIFxlJA)
[ntttcp-for-linux-logs.txt](https://microsoft.sharepoint.com/:t:/t/AzurePerfInvestigations/ERL4_3C0B2NOmP15zZ_th6cBtj3D3ID9nBo3UiUgvvKKSg)