### PR TITLE
Add missing outputs to xml logging. 

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -359,6 +359,7 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	char os_info_escaped[2048];
 	size_t count = 0;
 	unsigned int i;
+	int total_conns_created = 0;
 
 	memset(hostname, '\0', sizeof(char) * 256);
 	memset(os_info_escaped, '\0', sizeof(char) * 2048);
@@ -419,7 +420,11 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 			fprintf(logfile, "	</thread>\n");
 		}
 	}
-
+	if (tep->test->client_role == true) {
+		for (i = 0; i < tep->total_threads; i++)
+			total_conns_created += tep->client_streams[i]->num_conns_created;
+		fprintf(logfile, "	<conns_tested>%d</conns_tested>\n", total_conns_created);
+	}
 	fprintf(logfile, "	<total_bytes metric=\"MB\">%.6f</total_bytes>\n", tepr->total_bytes_MB);
 	fprintf(logfile, "	<realtime metric=\"s\">%.6f</realtime>\n", tepr->actual_test_time);
 	fprintf(logfile, "	<avg_bytes_per_compl metric=\"B\">%.3f</avg_bytes_per_compl>\n", 0.000);
@@ -439,15 +444,29 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	fprintf(logfile, "	<packets_received>%" PRIu64 "</packets_received>\n", tepr->packets_received);
 	fprintf(logfile, "	<packets_retransmitted>%" PRIu64 "</packets_retransmitted>\n", tepr->packets_retransmitted);
 	fprintf(logfile, "	<errors>%d</errors>\n", tepr->errors);
-	fprintf(logfile, "	<cpu metric=\"%%\">%.3f</cpu>\n", tepr->cpu_busy_percent * 100);
 	fprintf(logfile, "	<bufferCount>%u</bufferCount>\n", 0);
 	fprintf(logfile, "	<bufferLen>%u</bufferLen>\n", 0);
-	fprintf(logfile, "	<io>%u</io>\n", 0);
-
-	if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
-		fprintf(logfile, "	<tcp_average_rtt metric=\"us\">%u</tcp_average_rtt>\n", tepr->average_rtt);
+	
+	if (tepr->final_cpu_ps->nproc == tepr->init_cpu_ps->nproc){
+		fprintf(logfile, "	<cpu_cores metric=\"cpu cores\">%d</cpu_cores>\n", tepr->final_cpu_ps->nproc);
+	} else {
+		fprintf(logfile, "	<cpu_cores>number of CPUs does not match: initial: %d; final: %d</cpu_cores>\n",
+		tepr->init_cpu_ps->nproc, tepr->final_cpu_ps->nproc);
 	}
-
+	fprintf(logfile, "	<cpu_speed metric=\"MHz\">%.3f</cpu_speed>\n", tepr->cpu_speed_mhz);
+	fprintf(logfile, "	<user metric=\"%%\">%.2f</user>\n", tepr->cpu_ps_user_usage * 100);
+	fprintf(logfile, "	<system metric=\"%%\">%.2f</system>\n", tepr->cpu_ps_system_usage * 100);
+	fprintf(logfile, "	<idle metric=\"%%\">%.2f</idle>\n", tepr->cpu_ps_idle_usage * 100);
+	fprintf(logfile, "	<iowait metric=\"%%\">%.2f</iowait>\n", tepr->cpu_ps_iowait_usage * 100);
+	fprintf(logfile, "	<softirq metric=\"%%\">%.2f</softirq>\n", tepr->cpu_ps_softirq_usage * 100);
+	fprintf(logfile, "	<cycles_per_byte metric=\"cycles/byte\">%.2f</cycles_per_byte>\n", tepr->cycles_per_byte);
+	fprintf(logfile, "	<cpu_busy_all metric=\"%%\">%.2f</cpu_busy_all>\n", tepr->cpu_busy_percent * 100);
+	fprintf(logfile, "	<io>%u</io>\n", 0);
+	if (test->verbose){
+		if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
+			fprintf(logfile, "	<tcp_average_rtt metric=\"us\">%u</tcp_average_rtt>\n", tepr->average_rtt);
+		}
+	}
 	count = execute_system_cmd_by_process("uname -a", "r", &os_info);
 	if (os_info) {
 		escape_char_for_xml(os_info, os_info_escaped);

--- a/src/util.c
+++ b/src/util.c
@@ -420,11 +420,13 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 			fprintf(logfile, "	</thread>\n");
 		}
 	}
+
 	if (tep->test->client_role == true) {
 		for (i = 0; i < tep->total_threads; i++)
 			total_conns_created += tep->client_streams[i]->num_conns_created;
 		fprintf(logfile, "	<conns_tested>%d</conns_tested>\n", total_conns_created);
 	}
+
 	fprintf(logfile, "	<total_bytes metric=\"MB\">%.6f</total_bytes>\n", tepr->total_bytes_MB);
 	fprintf(logfile, "	<realtime metric=\"s\">%.6f</realtime>\n", tepr->actual_test_time);
 	fprintf(logfile, "	<avg_bytes_per_compl metric=\"B\">%.3f</avg_bytes_per_compl>\n", 0.000);
@@ -439,7 +441,6 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	fprintf(logfile, "	<interrupts metric=\"count/sec\">%.3f</interrupts>\n", 0.000);
 	fprintf(logfile, "	<dpcs metric=\"count/sec\">%.3f</dpcs>\n", 0.000);
 	fprintf(logfile, "	<avg_packets_per_dpc metric=\"packets/dpc\">%.3f</avg_packets_per_dpc>\n", 0.000);
-	fprintf(logfile, "	<cycles metric=\"cycles/byte\">%.3f</cycles>\n", tepr->cycles_per_byte);
 	fprintf(logfile, "	<packets_sent>%" PRIu64 "</packets_sent>\n", tepr->packets_sent);
 	fprintf(logfile, "	<packets_received>%" PRIu64 "</packets_received>\n", tepr->packets_received);
 	fprintf(logfile, "	<packets_retransmitted>%" PRIu64 "</packets_retransmitted>\n", tepr->packets_retransmitted);
@@ -467,6 +468,7 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 			fprintf(logfile, "	<tcp_average_rtt metric=\"us\">%u</tcp_average_rtt>\n", tepr->average_rtt);
 		}
 	}
+	
 	count = execute_system_cmd_by_process("uname -a", "r", &os_info);
 	if (os_info) {
 		escape_char_for_xml(os_info, os_info_escaped);
@@ -647,10 +649,11 @@ int write_result_into_json_file(struct ntttcp_test_endpoint *tep)
 	fprintf(json_file, "        \"bufferLen\" : \"%u\",\n", 0);
 	fprintf(json_file, "        \"io\" : \"%u\",\n", 0);
 
-	if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
-		fprintf(json_file, "        \"tcpAverageRtt metric\" : \"%u us\",\n", tepr->average_rtt);
+	if(test->verbose){
+		if (tep->endpoint_role == ROLE_SENDER && test->protocol == TCP) {
+			fprintf(json_file, "        \"tcpAverageRtt metric\" : \"%u us\",\n", tepr->average_rtt);
+		}
 	}
-
 	count = execute_system_cmd_by_process("uname -a", "r", &os_info);
 	if (os_info) {
 		escape_char_for_json(os_info, os_info_escaped);


### PR DESCRIPTION
Changed xml logging to have output parity with txt logging.
Below are links to txt and xml output from a sample run between two Ubuntu machines with the following commands:
ntttcp -s10.0.0.11 -L -n 2 -l 3 -t 300 -b 124k --show-dev-interrupts mlx -W 5
ntttcp -r -D -M 1 -t 300 -b 64k -P 16 -W 5 --show-dev-interrupts mlx

[ntttcp-for-linux-logs.xml](https://microsoft.sharepoint.com/:u:/t/AzurePerfInvestigations/EZ2rLFMj0UZFrfJZovl58yQBIBGVQkDGbOdBF5_LIFxlJA)
[ntttcp-for-linux-logs.txt](https://microsoft.sharepoint.com/:t:/t/AzurePerfInvestigations/ERL4_3C0B2NOmP15zZ_th6cBtj3D3ID9nBo3UiUgvvKKSg)