### PR TITLE
Fix improper closing of a `FILE` object opened with `popen()`.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,6 +38,9 @@ parameter.o: parameter.c
 main.o: main.c
 	$(CC) $(CFLAGS) -c main.c -o main.o
 
+.PHONY: all
+all: $(OUT)
+
 .PHONY: clean
 clean:
 	rm -rf *.o $(OUT)

--- a/src/util.c
+++ b/src/util.c
@@ -288,7 +288,11 @@ size_t execute_system_cmd_by_process(char *command, char *type, char **output)
 
 	count = getline(output, &len, pfp);
 
-	fclose(pfp);
+	if (pclose(pfp) == -1) {
+		PRINT_ERR("Error closing process");
+		return 0;
+	}
+
 	return count;
 }
 


### PR DESCRIPTION
 * added `all` target to the Makefile