### PR TITLE
Ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,18 @@ jobs:
           name: ${{ steps.binary_filename.outputs.version }}-aarch64
           path: src/ntttcp
           retention-days: 5
+
+
+  release_artifacts:
+    name: release artifacts
+    runs-on: ubuntu-22.04
+    needs: [build_x86-64, build_aarch64]
+    steps:
+      - name: releases the artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ntttcp-x86_64
+            ntttcp-aarch64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
 
-      - name: Defines the name of the binary file
-        run: echo "::set-output name=version::$( basename $(ls src/ntttcp) )"
-        id: binary_filename
-
       - name: Uploads binary file for x86-64
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.binary_filename.outputs.version }}-x86_64
+          name: ntttcp-x86_64
           path: src/ntttcp
           retention-days: 5
 
@@ -38,14 +34,10 @@ jobs:
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
             cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
 
-      - name: Defines the name of the binary file
-        run: echo "::set-output name=version::$( basename $(ls src/ntttcp) )"
-        id: binary_filename
-
       - name: Uploads binary file for aarch64
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.binary_filename.outputs.version }}-aarch64
+          name: ntttcp-aarch64
           path: src/ntttcp
           retention-days: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: make
+      - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
 
   build_aarch64:
     name: build aarch64
     runs-on: ubuntu-22.04
-      matrix:
-        toolchain:
-          - stable
-          - beta
-        include:
-          - arch: aarch64
-            distro: ubuntu22.04
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_x86-64:
     name: build x86-64
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
@@ -21,7 +21,7 @@ jobs:
 
   build_aarch64:
     name: build aarch64
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
@@ -29,7 +29,7 @@ jobs:
         id: build
         with:
           arch: aarch64
-          distro: ubuntu18.04
+          distro: ubuntu20.04
           run: |
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
             cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         id: binary_filename
 
       - name: Uploads binary file for x86-64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.binary_filename.outputs.version }}-x86_64
           path: src/ntttcp
@@ -43,7 +43,7 @@ jobs:
         id: binary_filename
 
       - name: Uploads binary file for aarch64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.binary_filename.outputs.version }}-aarch64
           path: src/ntttcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ jobs:
       - uses: actions/checkout@v4
       - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
 
+      - name: Defines the name of the binary file
+        run: echo "::set-output name=version::$( basename $(ls src/ntttcp) )"
+        id: binary_filename
+
+      - name: Uploads binary file for x86-64
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.binary_filename.outputs.version }}-x86_64
+          path: src/ntttcp
+          retention-days: 5
+
   build_aarch64:
     name: build aarch64
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     needs: [build_x86-64, build_aarch64]
     steps:
       - name: releases the artifacts
+        if: startsWith(github.ref, 'refs/heads/release/')
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         name: Build artifact
         id: build
         with:
-          arch: ${{ matrix.arch }}
-          distro: ${{ matrix.distro }}
+          arch: aarch64
+          distro: ubuntu22.04
           run: |
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
             cd src/ && cmake . && make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: Build using CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_x86-64:
+    name: build x86-64
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: make
+
+  build_aarch64:
+    name: build aarch64
+    runs-on: ubuntu-22.04
+      matrix:
+        toolchain:
+          - stable
+          - beta
+        include:
+          - arch: aarch64
+            distro: ubuntu22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          run: |
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
+            cd src/ && cmake . && make
+            ls -lh src/ntttcp && file src/ntttcp
+
+      - name: Defines the name of the binary file
+        run: echo "::set-output name=version::$( basename $(ls src/ntttcp) )"
+        id: binary_filename
+
+      - name: Uploads binary file for aarch64
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.binary_filename.outputs.version }}-aarch64
+          path: src/ntttcp
+          retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_x86-64:
     name: build x86-64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v4
       - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
@@ -21,7 +21,7 @@ jobs:
 
   build_aarch64:
     name: build aarch64
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
@@ -29,7 +29,7 @@ jobs:
         id: build
         with:
           arch: aarch64
-          distro: ubuntu22.04
+          distro: ubuntu18.04
           run: |
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
             cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
           distro: ubuntu22.04
           run: |
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
-            cd src/ && cmake . && make
-            ls -lh src/ntttcp && file src/ntttcp
+            cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
 
       - name: Defines the name of the binary file
         run: echo "::set-output name=version::$( basename $(ls src/ntttcp) )"


### PR DESCRIPTION
Just as mentioned in issue #87, it is not a good practice to ask a customer to build a tool by adding development environment to a production server, but instead it is expected to build binaries and make them available with a release.

This new file add a continued integration recipe for building binaries for both x86-64 and aarch64 (arm64) architectures available in Azure. Once a release is made, we can then update the README to instruct the cx to download the binary for their arch directly from GitHub.