### PR TITLE
Add an int parameter to the timer_fired function

### DIFF
--- a/src/multithreading.c
+++ b/src/multithreading.c
@@ -68,7 +68,7 @@ void sig_handler(int signo)
 	}
 }
 
-void timer_fired()
+void timer_fired(int)
 {
 	turn_off_light();
 }


### PR DESCRIPTION
I encountered an error when compiling a project using `make` on `Fedora 42`, as follows:
```bash
multithreading.c:85:29: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
   85 |         if (signal(SIGALRM, timer_fired) == SIG_ERR) {
      |                             ^~~~~~~~~~~
      |                             |
      |                             void (*)(void)
```
The prototype of the signal function is `sighandler_t signal(int signum, sighandler_t handler);`
And `typedef typeof(void (int)) *sighandler_t;`

Compiling normally under `Ubuntu 24`. I think the reason under Ubuntu may be due to the loose warning policy - but this does not mean the behavior is correct, so I added an int parameter.