### PR TITLE
Fix GCC compile error for parameter name omitted

### DIFF
--- a/src/multithreading.c
+++ b/src/multithreading.c
@@ -68,8 +68,9 @@ void sig_handler(int signo)
 	}
 }
 
-void timer_fired(int)
+void timer_fired(int signo)
 {
+	(void)signo;
 	turn_off_light();
 }
 


### PR DESCRIPTION
This PR fixes the compilation error.

cc -Wall -W -O2 -fno-strict-aliasing -c ntttcp.c -o ntttcp.o
cc -Wall -W -O2 -fno-strict-aliasing -c logger.c -o logger.o
cc -Wall -W -O2 -fno-strict-aliasing -c oscounter.c -o oscounter.o
cc -Wall -W -O2 -fno-strict-aliasing -c util.c -o util.o
cc -Wall -W -O2 -fno-strict-aliasing -c throughputmanagement.c -o throughputmanagement.o
cc -Wall -W -O2 -fno-strict-aliasing -c tcpstream.c -o tcpstream.o
cc -Wall -W -O2 -fno-strict-aliasing -c udpstream.c -o udpstream.o
cc -Wall -W -O2 -fno-strict-aliasing -c endpointsync.c -o endpointsync.o
cc -Wall -W -O2 -fno-strict-aliasing -c multithreading.c -o multithreading.o
cc -Wall -W -O2 -fno-strict-aliasing -c parameter.c -o parameter.o
cc -Wall -W -O2 -fno-strict-aliasing -c main.c -o main.o
multithreading.c: In function �timer_fired�:
multithreading.c:71:1: error: parameter name omitted
  void timer_fired(int)
  ^~~~
make: *** [Makefile:35: multithreading.o] Error 1