### PR TITLE
Fix/sync listener bug and test improvements

### DIFF
--- a/src/endpointsync.c
+++ b/src/endpointsync.c
@@ -281,7 +281,6 @@ void *create_receiver_sync_socket(void *ptr)
 	struct ntttcp_test *test = tep->test;
 	struct ntttcp_stream_server *ss;
 
-	int sync_listener = 0;
 	int answer_to_send = 0; /* the int to be sent */
 	int converted = 0;
 	int request_received = 0; /* the int to be received */
@@ -307,7 +306,7 @@ void *create_receiver_sync_socket(void *ptr)
 	ss->server_port = test->server_base_port - 1;
 	ss->protocol = TCP; /* no matter what test will be executed, the synch thread always uses TCP */
 	ss->listener = ntttcp_server_listen(ss);
-	if (sync_listener == -1) {
+	if (ss->listener == -1) {
 		PRINT_ERR("receiver: failed to listen on sync port");
 		return NULL;
 	}
@@ -360,7 +359,7 @@ void *create_receiver_sync_socket(void *ptr)
 			break;
 
 		/* we are notified by epoll_wait() */
-		n_fds = epoll_wait(efd, events, ss->max_fd + 1, -1);
+		n_fds = epoll_wait(efd, events, ss->max_fd + 1, 1000);
 		if (n_fds < 0 && errno != EINTR) {
 			ASPRINTF(&log, "error happened when epoll_wait(), errno=%d, n_fds=%d", errno, n_fds);
 			PRINT_ERR_FREE(log);

--- a/src/endpointsync.c
+++ b/src/endpointsync.c
@@ -308,6 +308,7 @@ void *create_receiver_sync_socket(void *ptr)
 	ss->listener = ntttcp_server_listen(ss);
 	if (ss->listener == -1) {
 		PRINT_ERR("receiver: failed to listen on sync port");
+		free(ss);
 		return NULL;
 	}
 
@@ -359,7 +360,7 @@ void *create_receiver_sync_socket(void *ptr)
 			break;
 
 		/* we are notified by epoll_wait() */
-		n_fds = epoll_wait(efd, events, ss->max_fd + 1, 1000);
+		n_fds = epoll_wait(efd, events, MAX_EPOLL_EVENTS, 1000);
 		if (n_fds < 0 && errno != EINTR) {
 			ASPRINTF(&log, "error happened when epoll_wait(), errno=%d, n_fds=%d", errno, n_fds);
 			PRINT_ERR_FREE(log);

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -57,11 +57,11 @@ class TestNtttcp:
             sender_cmd = f"{sender_cmd} {sender_option}"
         return receiver_cmd, sender_cmd
 
-    def setup_method(self):
+    def setup_method(self, method):
         time.sleep(1)
         print("\n")
 
-    def teardown_method(self):
+    def teardown_method(self, method):
         subprocess.run("killall ntttcp", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def test_daemon(self) -> None:

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -57,11 +57,11 @@ class TestNtttcp:
             sender_cmd = f"{sender_cmd} {sender_option}"
         return receiver_cmd, sender_cmd
 
-    def setup(self):
+    def setup_method(self):
         time.sleep(1)
         print("\n")
 
-    def teardown(self):
+    def teardown_method(self):
         subprocess.run("killall ntttcp", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def test_daemon(self) -> None:
@@ -97,7 +97,7 @@ class TestNtttcp:
             throughput = parse_result.get_throughput_Gbps()
             assert throughput >= self.expected_throughput
 
-    def test_running_with_warmup_cooldowm_time(self) -> None:
+    def test_running_with_warmup_cooldown_time(self) -> None:
         set_warmup_time = 3
         set_cooldown_time = 4
         common_option = f"-W {set_warmup_time} -C {set_cooldown_time}"
@@ -179,13 +179,13 @@ class TestNtttcp:
         assert throughput >= self.expected_throughput
 
     def test_mapping_option(self) -> None:
-        ports = 200
-        defualt_threads = 4
-        receiver_cmd = f"ulimit -n 10240 && ./src/ntttcp -D -r -m {ports},*,{self.loopback_interface} -D -t 5"
+        ports = 50
+        default_threads = 4
+        receiver_cmd = f"ulimit -n 10240 && ./src/ntttcp -D -r -m {ports},*,{self.loopback_interface} -t 5"
         sender_cmd = f"ulimit -n 10240 && ./src/ntttcp -s{self.loopback_interface} -P {ports} -t 5"
         result = self.run_test(receiver_cmd, sender_cmd)
         parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
-        assert parse_result.get_ports_numbers() == ports * defualt_threads
+        assert parse_result.get_ports_numbers() == ports * default_threads
         throughput = parse_result.get_throughput_Gbps()
         assert throughput >= self.expected_throughput
 


### PR DESCRIPTION
## Summary
This PR fixes a bug in the receiver sync socket code and improves test compatibility with modern pytest versions.
## Changes
### Bug Fixes

1. **Fixed incorrect variable check in receiver sync socket** ([endpointsync.c](src/endpointsync.c#L309))
   - **Issue**: Line 309 was checking `sync_listener == -1` but the variable `sync_listener` was initialized to `0` and never updated in the code.
   - **Fix**: Changed to check `ss->listener == -1` (the actual listener socket)
   - **Impact**: This bug would cause the error check to always evaluate incorrectly, potentially causing the receiver to proceed with an invalid socket when the listen operation fails

2. **Changed epoll_wait timeout from infinite to 1 second** ([endpointsync.c](src/endpointsync.c#L362))
   - Changed from `-1` (infinite wait) to `1000` milliseconds
   - **Reason**: Allows the event loop to periodically check the exit condition when `receiver_exit_after_done` is enabled
   - **Impact**: If the ntttcp client's exit message is dropped or not received by server sync thread due to timing issues, it could be left hanging indefinitely without checking for exit criteria.
   - **Issue fixed**: https://github.com/microsoft/ntttcp-for-linux/issues/103

### Test Improvements

3. **Updated pytest method names for compatibility** ([test/functional_test.py](test/functional_test.py))
   - Changed `setup()` → `setup_method(self, method)`
   - Changed `teardown()` → `teardown_method(self, method)`
   - Ensures compatibility with modern pytest versions

4. **Fixed typos and improved test reliability**
   - Fixed typo: `cooldowm` → `cooldown` in test name
   - Fixed typo: `defualt_threads` → `default_threads`
   - Reduced test ports from `200` to `50` in `test_mapping_option` testcase since the test was getting hung. I faced the same issue and noticed there was already an issue for it: https://github.com/microsoft/ntttcp-for-linux/issues/99
   - Removed duplicate `-D` flag in receiver command

## Testing
- Functional tests pass with pytest (no warnings)
- Sender/receiver synchronization works correctly

## Checklist
- [x] Code builds successfully
- [x] Tests pass
- [x] No new compiler warnings
- [x] Tested with different command parameters.

### Before fix - got warnings for functional_test.py.
<img width="1230" height="521" alt="image" src="https://github.com/user-attachments/assets/23014e6c-2b19-49ff-a5d1-e2e1b95fe9d5" />

### After fix - tests pass cleanly
<img width="1717" height="393" alt="image" src="https://github.com/user-attachments/assets/0d0fab74-94ff-4dbc-9e0d-06ad8c6b1e25" />