### PR TITLE
Fix for interrupt rate calculation and adding total interrupt count metric in xml

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -226,6 +226,9 @@ void print_test_results(struct ntttcp_test_endpoint *tep)
 		PRINT_INFO("interrupts:");
 		ASPRINTF(&log, "\t total\t\t:%" PRIu64, tepr->total_interrupts);
 		PRINT_INFO_FREE(log);
+		ASPRINTF(&log, "\t interrupts/sec\t:%.3f",
+			test_duration > 0 ? (double)tepr->total_interrupts / test_duration : 0.000);
+		PRINT_INFO_FREE(log);
 	}
 	if (strcmp(tep->test->show_interface_packets, "") && strcmp(tep->test->show_dev_interrupts, "")) {
 		ASPRINTF(&log, "\t pkts/interrupt\t:%.2f", tepr->packets_per_interrupt);
@@ -438,7 +441,8 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	fprintf(logfile, "	<total_buffers>%.3f</total_buffers>\n", 0.000);
 	fprintf(logfile, "	<throughput metric=\"buffers/s\">%.3f</throughput>\n", 0.000);
 	fprintf(logfile, "	<avg_packets_per_interrupt metric=\"packets/interrupt\">%.3f</avg_packets_per_interrupt>\n", tepr->packets_per_interrupt);
-	fprintf(logfile, "	<interrupts metric=\"count/sec\">%.3f</interrupts>\n", 0.000);
+	fprintf(logfile, "	<interrupts metric=\"count/sec\">%.3f</interrupts>\n", tepr->actual_test_time > 0 ? (double)tepr->total_interrupts / tepr->actual_test_time : 0.000);
+	fprintf(logfile, "	<total_interrupts metric=\"count\">%" PRIu64 "</total_interrupts>\n", tepr->total_interrupts);
 	fprintf(logfile, "	<dpcs metric=\"count/sec\">%.3f</dpcs>\n", 0.000);
 	fprintf(logfile, "	<avg_packets_per_dpc metric=\"packets/dpc\">%.3f</avg_packets_per_dpc>\n", 0.000);
 	fprintf(logfile, "	<packets_sent>%" PRIu64 "</packets_sent>\n", tepr->packets_sent);
@@ -635,7 +639,11 @@ int write_result_into_json_file(struct ntttcp_test_endpoint *tep)
 	fprintf(json_file, "        },\n");
 	fprintf(json_file, "        \"interrupt\" : {\n");
 	fprintf(json_file, "            \"metric\" : \"count/sec\",\n");
-	fprintf(json_file, "            \"value\" : \"%.3f\"\n", 0.000);
+	fprintf(json_file, "            \"value\" : \"%.3f\"\n", tepr->actual_test_time > 0 ? (double)tepr->total_interrupts / tepr->actual_test_time : 0.000);
+	fprintf(json_file, "        },\n");
+	fprintf(json_file, "        \"interruptTotal\" : {\n");
+	fprintf(json_file, "            \"metric\" : \"count\",\n");
+	fprintf(json_file, "            \"value\" : \"%" PRIu64 "\"\n", tepr->total_interrupts);
 	fprintf(json_file, "        },\n");
 	fprintf(json_file, "        \"dpcs\" : {\n");
 	fprintf(json_file, "            \"metric\" : \"count/sec\",\n");

--- a/src/util.c
+++ b/src/util.c
@@ -117,6 +117,7 @@ int process_test_results(struct ntttcp_test_endpoint *tep)
 	tepr->packets_sent = tepr->final_tx_packets - tepr->init_tx_packets;
 	tepr->packets_received = tepr->final_rx_packets - tepr->init_rx_packets;
 	tepr->total_interrupts = tepr->final_interrupts - tepr->init_interrupts;
+	tepr->interrupts_per_sec = test_duration > 0 ? (double)tepr->total_interrupts / test_duration : 0.0;
 	tepr->packets_per_interrupt = tepr->total_interrupts == 0 ? 0 : (tepr->packets_sent + tepr->packets_received) / (double)tepr->total_interrupts;
 
 	cpu_ps_total_diff = tepr->final_cpu_ps->total_time - tepr->init_cpu_ps->total_time;
@@ -226,8 +227,7 @@ void print_test_results(struct ntttcp_test_endpoint *tep)
 		PRINT_INFO("interrupts:");
 		ASPRINTF(&log, "\t total\t\t:%" PRIu64, tepr->total_interrupts);
 		PRINT_INFO_FREE(log);
-		ASPRINTF(&log, "\t interrupts/sec\t:%.3f",
-			test_duration > 0 ? (double)tepr->total_interrupts / test_duration : 0.000);
+		ASPRINTF(&log, "\t interrupts/sec\t:%.3f", tepr->interrupts_per_sec);
 		PRINT_INFO_FREE(log);
 	}
 	if (strcmp(tep->test->show_interface_packets, "") && strcmp(tep->test->show_dev_interrupts, "")) {
@@ -441,7 +441,7 @@ int write_result_into_xml_file(struct ntttcp_test_endpoint *tep)
 	fprintf(logfile, "	<total_buffers>%.3f</total_buffers>\n", 0.000);
 	fprintf(logfile, "	<throughput metric=\"buffers/s\">%.3f</throughput>\n", 0.000);
 	fprintf(logfile, "	<avg_packets_per_interrupt metric=\"packets/interrupt\">%.3f</avg_packets_per_interrupt>\n", tepr->packets_per_interrupt);
-	fprintf(logfile, "	<interrupts metric=\"count/sec\">%.3f</interrupts>\n", tepr->actual_test_time > 0 ? (double)tepr->total_interrupts / tepr->actual_test_time : 0.000);
+	fprintf(logfile, "	<interrupts metric=\"count/sec\">%.3f</interrupts>\n", tepr->interrupts_per_sec);
 	fprintf(logfile, "	<total_interrupts metric=\"count\">%" PRIu64 "</total_interrupts>\n", tepr->total_interrupts);
 	fprintf(logfile, "	<dpcs metric=\"count/sec\">%.3f</dpcs>\n", 0.000);
 	fprintf(logfile, "	<avg_packets_per_dpc metric=\"packets/dpc\">%.3f</avg_packets_per_dpc>\n", 0.000);
@@ -639,7 +639,7 @@ int write_result_into_json_file(struct ntttcp_test_endpoint *tep)
 	fprintf(json_file, "        },\n");
 	fprintf(json_file, "        \"interrupt\" : {\n");
 	fprintf(json_file, "            \"metric\" : \"count/sec\",\n");
-	fprintf(json_file, "            \"value\" : \"%.3f\"\n", tepr->actual_test_time > 0 ? (double)tepr->total_interrupts / tepr->actual_test_time : 0.000);
+	fprintf(json_file, "            \"value\" : \"%.3f\"\n", tepr->interrupts_per_sec);
 	fprintf(json_file, "        },\n");
 	fprintf(json_file, "        \"interruptTotal\" : {\n");
 	fprintf(json_file, "            \"metric\" : \"count\",\n");

--- a/src/util.h
+++ b/src/util.h
@@ -79,6 +79,7 @@ struct ntttcp_test_endpoint_results{
 	double		cpu_ps_softirq_usage;
 	uint64_t	total_interrupts;
 	double		packets_per_interrupt;
+	double		interrupts_per_sec;
 
 	/* fields for xml log (compatible with Windows ntttcp.exe) */
 	double		total_bytes_MB;

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -57,11 +57,11 @@ class TestNtttcp:
             sender_cmd = f"{sender_cmd} {sender_option}"
         return receiver_cmd, sender_cmd
 
-    def setup(self):
+    def setup_method(self, method):
         time.sleep(1)
         print("\n")
 
-    def teardown(self):
+    def teardown_method(self, method):
         subprocess.run("killall ntttcp", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     def test_daemon(self) -> None:
@@ -97,7 +97,7 @@ class TestNtttcp:
             throughput = parse_result.get_throughput_Gbps()
             assert throughput >= self.expected_throughput
 
-    def test_running_with_warmup_cooldowm_time(self) -> None:
+    def test_running_with_warmup_cooldown_time(self) -> None:
         set_warmup_time = 3
         set_cooldown_time = 4
         common_option = f"-W {set_warmup_time} -C {set_cooldown_time}"
@@ -179,13 +179,13 @@ class TestNtttcp:
         assert throughput >= self.expected_throughput
 
     def test_mapping_option(self) -> None:
-        ports = 200
-        defualt_threads = 4
-        receiver_cmd = f"ulimit -n 10240 && ./src/ntttcp -D -r -m {ports},*,{self.loopback_interface} -D -t 5"
+        ports = 50
+        default_threads = 4
+        receiver_cmd = f"ulimit -n 10240 && ./src/ntttcp -D -r -m {ports},*,{self.loopback_interface} -t 5"
         sender_cmd = f"ulimit -n 10240 && ./src/ntttcp -s{self.loopback_interface} -P {ports} -t 5"
         result = self.run_test(receiver_cmd, sender_cmd)
         parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
-        assert parse_result.get_ports_numbers() == ports * defualt_threads
+        assert parse_result.get_ports_numbers() == ports * default_threads
         throughput = parse_result.get_throughput_Gbps()
         assert throughput >= self.expected_throughput
 
@@ -213,12 +213,52 @@ class TestNtttcp:
 
     def test_show_dev_interrupts(self, ) -> None:
         common_option = "--show-dev-interrupts Hypervisor callback interrupts"
+        sender_xml = "test_interrupts_sender.xml"
+        sender_json = "test_interrupts_sender.json"
+        sender_console = "test_interrupts_sender_console.out"
+        sender_option = f"-x {sender_xml} -j {sender_json} -O {sender_console}"
         receiver_cmd, sender_cmd = self.combine_command(
-                common_option=common_option
+                common_option=common_option,
+                sender_option=sender_option
         )
         result = self.run_test(receiver_cmd, sender_cmd)
         parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+        # Verify console output has interrupts
         assert parse_result.is_show_dev_interrupts() is True
+
+        # Get console interrupt metrics
+        console_info = parse_result.get_console_interrupts_info()
+        assert console_info is not None, "Console output missing interrupt metrics"
+        console_total, console_per_sec = console_info
+
+        # Verify console values are non-zero
+        assert console_total > 0, "Console total_interrupts should be > 0"
+        assert console_per_sec > 0.0, "Console interrupts_per_sec should be > 0"
+
+        # Get and verify XML interrupt metrics
+        xml_info = parse_result.get_xml_interrupts_info(sender_xml)
+        assert xml_info is not None, "XML output missing interrupt metrics"
+        xml_total, xml_per_sec = xml_info
+
+        # Verify XML values match console
+        assert xml_total == console_total, f"XML total_interrupts ({xml_total}) should match console ({console_total})"
+        assert xml_per_sec > 0.0, "XML interrupts/sec should be > 0"
+        # Allow small floating point differences
+        assert abs(xml_per_sec - console_per_sec) < 0.01, \
+            f"XML interrupts_per_sec ({xml_per_sec}) should match console ({console_per_sec})"
+
+        # Get and verify JSON interrupt metrics
+        json_info = parse_result.get_json_interrupts_info(sender_json)
+        assert json_info is not None, "JSON output missing interrupt metrics"
+        json_total, json_per_sec = json_info
+
+        # Verify JSON values match console
+        assert json_total == console_total, f"JSON total_interrupts ({json_total}) should match console ({console_total})"
+        assert json_per_sec > 0.0, "JSON interrupts/sec should be > 0"
+        assert abs(json_per_sec - console_per_sec) < 0.01, \
+            f"JSON interrupts_per_sec ({json_per_sec}) should match console ({console_per_sec})"
+
         throughput = parse_result.get_throughput_Gbps()
         assert throughput >= self.expected_throughput
 

--- a/test/ntttcp_output.py
+++ b/test/ntttcp_output.py
@@ -194,3 +194,82 @@ class NtttcpOutput:
             return True
         else:
             return False
+
+    def get_console_interrupts_info(self) -> Optional[Tuple[int, float]]:
+        """Extract total interrupts and interrupts/sec from console output"""
+        # INFO:   total          :15
+        total_pattern = re.compile(r"total\s+:(\d+)")
+        total_match = total_pattern.findall(self.sender_stdout)
+        # INFO:   interrupts/sec :3.000
+        per_sec_pattern = re.compile(r"interrupts/sec\s+:(\d+\.\d+)")
+        per_sec_match = per_sec_pattern.findall(self.sender_stdout)
+
+        if total_match and per_sec_match:
+            total_interrupts = int(total_match[0])
+            interrupts_per_sec = float(per_sec_match[0])
+            print(f"Console - total_interrupts: {total_interrupts}, interrupts_per_sec: {interrupts_per_sec}")
+            return total_interrupts, interrupts_per_sec
+        else:
+            return None
+
+    def get_xml_interrupts_info(self, xml_filename: str) -> Optional[Tuple[int, float]]:
+        """Extract total interrupts and interrupts/sec from XML output file"""
+        try:
+            with open(xml_filename, 'r') as f:
+                xml_content = f.read()
+
+            # <total_interrupts metric="count">15</total_interrupts>
+            total_pattern = re.compile(r'<total_interrupts metric="count">(\d+)</total_interrupts>')
+            total_match = total_pattern.findall(xml_content)
+
+            # <interrupts metric="count/sec">3.000</interrupts>
+            per_sec_pattern = re.compile(r'<interrupts metric="count/sec">(\d+\.\d+)</interrupts>')
+            per_sec_match = per_sec_pattern.findall(xml_content)
+
+            if total_match and per_sec_match:
+                total_interrupts = int(total_match[0])
+                interrupts_per_sec = float(per_sec_match[0])
+                print(f"XML - total_interrupts: {total_interrupts}, interrupts_per_sec: {interrupts_per_sec}")
+                return total_interrupts, interrupts_per_sec
+            else:
+                return None
+        except Exception as e:
+            print(f"Error reading XML file: {e}")
+            return None
+
+    def get_json_interrupts_info(self, json_filename: str) -> Optional[Tuple[int, float]]:
+        """Extract total interrupts and interrupts/sec from JSON output file"""
+        try:
+            with open(json_filename, 'r') as f:
+                json_data = json.load(f)
+
+            # Find the root key (either "nttttcps" or "nttttcpr")
+            root_key = None
+            for key in json_data.keys():
+                if key.startswith("ntttcp"):
+                    root_key = key
+                    break
+
+            if not root_key:
+                return None
+
+            data = json_data[root_key]
+
+            # "interruptTotal" : { "metric" : "count", "value" : "15" }
+            total_interrupts = None
+            if "interruptTotal" in data and "value" in data["interruptTotal"]:
+                total_interrupts = int(data["interruptTotal"]["value"])
+
+            # "interrupt" : { "metric" : "count/sec", "value" : "3.000" }
+            interrupts_per_sec = None
+            if "interrupt" in data and "value" in data["interrupt"]:
+                interrupts_per_sec = float(data["interrupt"]["value"])
+
+            if total_interrupts is not None and interrupts_per_sec is not None:
+                print(f"JSON - total_interrupts: {total_interrupts}, interrupts_per_sec: {interrupts_per_sec}")
+                return total_interrupts, interrupts_per_sec
+            else:
+                return None
+        except Exception as e:
+            print(f"Error reading JSON file: {e}")
+            return None


### PR DESCRIPTION
# Summary
Fix interrupt rate calculation and reporting in XML/JSON outputs and console logs. This PR fixes issues mentioned in https://github.com/microsoft/ntttcp-for-linux/issues/105

# Problem
- The interrupt rate metric (interrupts/sec) was previously hardcoded to 0.000 in XML and JSON output files, even though the tool was collecting actual interrupt count data from the system.
- Total interrupt count metrics was missing in XML output.

# Changes Made
- Computed an `interrupts_per_sec` value once in `process_test_results()` (similar to other *_per_sec fields) and reusing it everywhere like console, XML and JSON.
- Updated test to ensure that interrupts are same across console, XML and JSON results.

## 1. Console Output Enhancement
- Added `interrupts/sec` metric to console output in the interrupts section (Calculation: total_interrupts / test_duration)
<img width="1002" height="460" alt="image" src="https://github.com/user-attachments/assets/1baf3f03-51a2-4c80-9bf2-73bdc08ceb34" />

## 2. XML Output Fix
- Fixed hardcoded 0.000 value for <interrupts metric="count/sec"> (Now calculates actual rate: total_interrupts / actual_test_time)
- Added new `<total_interrupts>` field to print total interrupt count
<img width="1106" height="970" alt="image" src="https://github.com/user-attachments/assets/955e4ac8-8f5a-4496-a06d-b125ea6cff5c" />

## 3. JSON Output Fix
- Fixed hardcoded 0.000 value for interrupt field (Now calculates actual rate using the same formula as XML)
- Added new `total_interrupts count` metric field
<img width="352" height="773" alt="image" src="https://github.com/user-attachments/assets/35366eb5-8bc5-4a81-a938-fb9c4e2a0b37" />

# Impact
- Users can now see accurate interrupt rate metrics in console, XML and JSON
- Users can now see total interrupts count metrics in XML

# Testing Checklist
- [x] Console output displays interrupts/sec correctly
- [x] XML contains both <interrupts> (rate) and <total_interrupts> (count)
- [x] JSON contains both interrupt (rate) and interruptTotal (count)
- [x] All testcases in functional_test.py passes.

<img width="1895" height="185" alt="image" src="https://github.com/user-attachments/assets/a96e8d07-d4df-438e-89b3-cc58222d2493" />