### PR TITLE
Fix for memory leaks and resource management bugs

### DIFF
--- a/src/const.h
+++ b/src/const.h
@@ -5,7 +5,7 @@
 // ----------------------------------------------------------------------------------
 
 #define TOOL_NAME "NTTTCP for Linux"
-#define TOOL_VERSION "1.4.3"
+#define TOOL_VERSION "1.4.4"
 #define AUTHOR_NAME "Shihua (Simon) Xiao, sixiao@microsoft.com"
 
 #define TCP 				SOCK_STREAM

--- a/src/endpointsync.c
+++ b/src/endpointsync.c
@@ -319,6 +319,7 @@ void *create_receiver_sync_socket(void *ptr)
 	ASPRINTF(&port_str, "%d", ss->server_port);
 	if (getaddrinfo(test->bind_address, port_str, &hints, &serv_info) != 0) {
 		PRINT_ERR("cannot get address info for receiver");
+		free(port_str);
 		close(ss->listener);
 		free(ss);
 		return NULL;

--- a/src/endpointsync.c
+++ b/src/endpointsync.c
@@ -319,6 +319,8 @@ void *create_receiver_sync_socket(void *ptr)
 	ASPRINTF(&port_str, "%d", ss->server_port);
 	if (getaddrinfo(test->bind_address, port_str, &hints, &serv_info) != 0) {
 		PRINT_ERR("cannot get address info for receiver");
+		close(ss->listener);
+		free(ss);
 		return NULL;
 	}
 	free(port_str);
@@ -327,18 +329,19 @@ void *create_receiver_sync_socket(void *ptr)
 	if ((ip_address_str = (char *)malloc(ip_address_max_size)) == (char *)NULL) {
 		PRINT_ERR("cannot allocate memory for ip address string");
 		freeaddrinfo(serv_info);
+		close(ss->listener);
+		free(ss);
 		return NULL;
 	}
 
-	ip_address_max_size = (ss->domain == AF_INET ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN);
-	if ((ip_address_str = (char *)malloc(ip_address_max_size)) == (char *)NULL) {
-		PRINT_ERR("cannot allocate memory for ip address of peer");
-		return NULL;
-	}
+	freeaddrinfo(serv_info);
 
 	efd = epoll_create1(0);
 	if (efd == -1) {
 		PRINT_ERR("epoll_create1 failed");
+		free(ip_address_str);
+		close(ss->listener);
+		free(ss);
 		return NULL;
 	}
 
@@ -347,6 +350,9 @@ void *create_receiver_sync_socket(void *ptr)
 	if (epoll_ctl(efd, EPOLL_CTL_ADD, ss->listener, &event) != 0) {
 		PRINT_ERR("epoll_ctl failed");
 		close(efd);
+		free(ip_address_str);
+		close(ss->listener);
+		free(ss);
 		return NULL;
 	}
 
@@ -391,12 +397,16 @@ void *create_receiver_sync_socket(void *ptr)
 				if (set_socket_non_blocking(newfd) == -1) {
 					ASPRINTF(&log, "cannot set the new socket as non-blocking: %d", newfd);
 					PRINT_DBG_FREE(log);
+					close(newfd);
+					continue;
 				}
 
 				event.data.fd = newfd;
 				event.events = EPOLLIN;
 				if (epoll_ctl(efd, EPOLL_CTL_ADD, newfd, &event) != 0) {
 					PRINT_ERR("epoll_ctl failed");
+					close(newfd);
+					continue;
 				}
 				if (newfd > ss->max_fd) {
 					/* update the maximum */

--- a/src/main.c
+++ b/src/main.c
@@ -39,12 +39,14 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 		reply_received = query_receiver_busy_state(tep->synch_socket);
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to query receiver state");
-			close(tep->synch_socket);
+			if (test->no_synch == false)
+				close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received == 1) {
 			PRINT_ERR("sender: receiver is busy with another test");
-			close(tep->synch_socket);
+			if (test->no_synch == false)
+				close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 
@@ -52,7 +54,8 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 							   test->warmup + test->duration + test->cooldown);
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to negotiate test cycle time with receiver");
-			close(tep->synch_socket);
+			if (test->no_synch == false)
+				close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received != test->duration) {
@@ -148,12 +151,14 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 						  tep->test->last_client ? (int)'L' : (int)'R');
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to sync with receiver to start test");
-			close(tep->synch_socket);
+			if (test->no_synch == false)
+				close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received == 0) {
 			PRINT_ERR("sender: receiver refuse to start test right now");
-			close(tep->synch_socket);
+			if (test->no_synch == false)
+				close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 
@@ -340,7 +345,14 @@ int main(int argc, char **argv)
 		exit(-1);
 	}
 
-	default_ntttcp_test(test);
+	err_code = default_ntttcp_test(test);
+	if (err_code != NO_ERROR) {
+		PRINT_ERR("main: error when initializing default test parameters");
+		free(test->bind_address);
+		free(test);
+		exit(err_code);
+	}
+
 	err_code = parse_arguments(test, argc, argv);
 	if (err_code != NO_ERROR) {
 		PRINT_ERR("main: error when parsing args");

--- a/src/main.c
+++ b/src/main.c
@@ -39,10 +39,12 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 		reply_received = query_receiver_busy_state(tep->synch_socket);
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to query receiver state");
+			close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received == 1) {
 			PRINT_ERR("sender: receiver is busy with another test");
+			close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 
@@ -50,6 +52,7 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 							   test->warmup + test->duration + test->cooldown);
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to negotiate test cycle time with receiver");
+			close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received != test->duration) {
@@ -145,10 +148,12 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 						  tep->test->last_client ? (int)'L' : (int)'R');
 		if (reply_received == -1) {
 			PRINT_ERR("sender: failed to sync with receiver to start test");
+			close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 		if (reply_received == 0) {
 			PRINT_ERR("sender: receiver refuse to start test right now");
+			close(tep->synch_socket);
 			return ERROR_GENERAL;
 		}
 
@@ -162,6 +167,8 @@ int run_ntttcp_sender(struct ntttcp_test_endpoint *tep)
 	if (tep->negotiated_test_cycle_time == 0) {
 		sleep(UINT_MAX);
 		/* either sleep has elapsed, or sleep was interrupted by a signal */
+		if (test->no_synch == false)
+			close(tep->synch_socket);
 		return err_code;
 	}
 

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -29,11 +29,6 @@ int default_ntttcp_test(struct ntttcp_test *test)
 	test->use_client_address	= false;
 	test->exit_after_done		= true;
 	test->mapping			= "16,*,*";
-	test->bind_address		= strdup("0.0.0.0");
-	if (!test->bind_address) {
-		PRINT_ERR("failed to allocate memory for bind_address in defaults");
-		return ERROR_MEMORY_ALLOC;
-	}
 	test->client_address		= "0.0.0.0";
 	test->cpu_affinity		= -1; /* no hard cpu affinity */
 	test->server_ports		= DEFAULT_NUM_SERVER_PORTS;	 //default:16 */
@@ -63,6 +58,14 @@ int default_ntttcp_test(struct ntttcp_test *test)
 	test->json_log_filename		= DEFAULT_JSON_LOG_FILE_NAME; /* "ntttcp-for-linux-log.json" */
 	test->quiet			= false;
 	test->verbose			= false;
+
+	/* Allocate bind_address last to ensure all other fields are initialized if allocation fails */
+	test->bind_address		= strdup("0.0.0.0");
+	if (!test->bind_address) {
+		PRINT_ERR("failed to allocate memory for bind_address in defaults");
+		return ERROR_MEMORY_ALLOC;
+	}
+
 	return NO_ERROR;
 }
 

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -228,6 +228,7 @@ void free_ntttcp_test_endpoint_and_test(struct ntttcp_test_endpoint *e)
 
 	for (i = 0; i < total_threads; i++)
 		free(e->results->threads[i]);
+	free(e->results->threads);
 	free(e->results->init_cpu_usage);
 	free(e->results->init_cpu_ps);
 	free(e->results->init_tcp_retrans);

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -29,7 +29,11 @@ void default_ntttcp_test(struct ntttcp_test *test)
 	test->use_client_address	= false;
 	test->exit_after_done		= true;
 	test->mapping			= "16,*,*";
-	test->bind_address		= "0.0.0.0";
+	test->bind_address		= strdup("0.0.0.0");
+	if (!test->bind_address) {
+		PRINT_ERR("failed to allocate memory for bind_address in defaults");
+		exit(-1);
+	}
 	test->client_address		= "0.0.0.0";
 	test->cpu_affinity		= -1; /* no hard cpu affinity */
 	test->server_ports		= DEFAULT_NUM_SERVER_PORTS;	 //default:16 */
@@ -237,6 +241,7 @@ void free_ntttcp_test_endpoint_and_test(struct ntttcp_test_endpoint *e)
 	free(e->results->final_tcp_retrans);
 	free(e->results);
 	free(e->threads);
+	free(e->test->bind_address);
 	free(e->test);
 	free(e);
 }

--- a/src/ntttcp.c
+++ b/src/ntttcp.c
@@ -18,7 +18,7 @@ struct ntttcp_test *new_ntttcp_test()
 	return test;
 }
 
-void default_ntttcp_test(struct ntttcp_test *test)
+int default_ntttcp_test(struct ntttcp_test *test)
 {
 	test->server_role		= false;
 	test->client_role		= false;
@@ -32,7 +32,7 @@ void default_ntttcp_test(struct ntttcp_test *test)
 	test->bind_address		= strdup("0.0.0.0");
 	if (!test->bind_address) {
 		PRINT_ERR("failed to allocate memory for bind_address in defaults");
-		exit(-1);
+		return ERROR_MEMORY_ALLOC;
 	}
 	test->client_address		= "0.0.0.0";
 	test->cpu_affinity		= -1; /* no hard cpu affinity */
@@ -63,6 +63,7 @@ void default_ntttcp_test(struct ntttcp_test *test)
 	test->json_log_filename		= DEFAULT_JSON_LOG_FILE_NAME; /* "ntttcp-for-linux-log.json" */
 	test->quiet			= false;
 	test->verbose			= false;
+	return NO_ERROR;
 }
 
 bool is_running_tty(void)

--- a/src/ntttcp.h
+++ b/src/ntttcp.h
@@ -143,7 +143,7 @@ struct ntttcp_stream_server{
 };
 
 struct ntttcp_test *new_ntttcp_test();
-void default_ntttcp_test(struct ntttcp_test *test);
+int default_ntttcp_test(struct ntttcp_test *test);
 
 struct ntttcp_test_endpoint *new_ntttcp_test_endpoint(struct ntttcp_test *test, int endpoint_role);
 void set_ntttcp_test_endpoint_test_continuous(struct ntttcp_test_endpoint* e);

--- a/src/oscounter.c
+++ b/src/oscounter.c
@@ -87,8 +87,10 @@ uint64_t get_interrupts_from_proc_by_dev(char *dev_name)
 		PRINT_ERR("Cannot open /proc/interrupts");
 		return 0;
 	}
-	if (!strcmp(dev_name, ""))
+	if (!strcmp(dev_name, "")) {
+		fclose(file);
 		return 0;
+	}
 
 	/* the max number of chars in each line = 64 + 12 chars/cpu * 1024 cpus + 128 = 12,480 */
 	char buffer[12480];

--- a/src/parameter.c
+++ b/src/parameter.c
@@ -202,12 +202,19 @@ int process_mappings(struct ntttcp_test *test)
 
 	state = S_THREADS;
 	char *element = strdup(test->mapping);
+	if (!element) {
+		PRINT_ERR("process_mappings: failed to allocate memory");
+		return ERROR_ARGS;
+	}
+	/* strsep() modifies the element pointer; save the original for proper free() */
+	char *element_start = element;
 
 	while ((token = strsep(&element, ",")) != NULL) {
 		if (S_THREADS == state) {
 			threads = atoi(token);
 
 			if (1 > threads) {
+				free(element_start);
 				return ERROR_ARGS;
 			}
 			test->server_ports = threads;
@@ -226,6 +233,7 @@ int process_mappings(struct ntttcp_test *test)
 
 				if (cpu < -1 || cpu > total_cpus - 1) {
 					PRINT_ERR("process_mappings: cpu specified is not in allowed scope");
+					free(element_start);
 					return ERROR_ARGS;
 				}
 				test->cpu_affinity = cpu;
@@ -236,9 +244,15 @@ int process_mappings(struct ntttcp_test *test)
 			++state;
 		} else {
 			PRINT_ERR("process_mappings: unexpected parameters in mapping");
+			free(element_start);
 			return ERROR_ARGS;
 		}
 	}
+	/*
+	 * element_start cannot be freed here: in the S_HOST case, test->bind_address
+	 * points into this buffer and must remain valid for the lifetime of the test.
+	 * The allocation is intentionally kept alive (small, one-time at startup).
+	 */
 	return NO_ERROR;
 }
 

--- a/src/parameter.c
+++ b/src/parameter.c
@@ -240,6 +240,7 @@ int process_mappings(struct ntttcp_test *test)
 			}
 			++state;
 		} else if (S_HOST == state) {
+			free(test->bind_address);
 			test->bind_address = strdup(token);
 			if (!test->bind_address) {
 				PRINT_ERR("process_mappings: failed to allocate memory for bind_address");

--- a/src/parameter.c
+++ b/src/parameter.c
@@ -439,6 +439,7 @@ int parse_arguments(struct ntttcp_test *test, int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 	int opt;
+	int err_code;
 
 	while ((opt = getopt_long(argc, argv, "r::s::DMLeHm:P:a:n:l:6up:f::b:B:W:t:C:NO::x::j::QVh", longopts, NULL)) != -1) {
 		switch (opt) {
@@ -491,7 +492,9 @@ int parse_arguments(struct ntttcp_test *test, int argc, char **argv)
 
 		case 'm':
 			test->mapping = optarg;
-			process_mappings(test);
+			err_code = process_mappings(test);
+			if (err_code != NO_ERROR)
+				return err_code;
 			break;
 
 		case 'P':

--- a/src/parameter.c
+++ b/src/parameter.c
@@ -240,7 +240,12 @@ int process_mappings(struct ntttcp_test *test)
 			}
 			++state;
 		} else if (S_HOST == state) {
-			test->bind_address = token;
+			test->bind_address = strdup(token);
+			if (!test->bind_address) {
+				PRINT_ERR("process_mappings: failed to allocate memory for bind_address");
+				free(element_start);
+				return ERROR_ARGS;
+			}
 			++state;
 		} else {
 			PRINT_ERR("process_mappings: unexpected parameters in mapping");
@@ -248,11 +253,7 @@ int process_mappings(struct ntttcp_test *test)
 			return ERROR_ARGS;
 		}
 	}
-	/*
-	 * element_start cannot be freed here: in the S_HOST case, test->bind_address
-	 * points into this buffer and must remain valid for the lifetime of the test.
-	 * The allocation is intentionally kept alive (small, one-time at startup).
-	 */
+	free(element_start);
 	return NO_ERROR;
 }
 
@@ -269,8 +270,14 @@ int verify_args(struct ntttcp_test *test)
 		return ERROR_ARGS;
 	}
 
-	if (test->domain == AF_INET6 && strcmp(test->bind_address, "0.0.0.0") == 0)
-		test->bind_address = "::";
+	if (test->domain == AF_INET6 && strcmp(test->bind_address, "0.0.0.0") == 0) {
+		free(test->bind_address);
+		test->bind_address = strdup("::");
+		if (!test->bind_address) {
+			PRINT_ERR("failed to allocate memory for bind_address");
+			return ERROR_ARGS;
+		}
+	}
 
 	if (test->domain == AF_INET6 && !strstr(test->bind_address, ":")) {
 		PRINT_ERR("invalid ipv6 address provided");
@@ -443,10 +450,21 @@ int parse_arguments(struct ntttcp_test *test, int argc, char **argv)
 			}
 
 			if (optarg) {
-				test->bind_address = optarg;
+				free(test->bind_address);
+				test->bind_address = strdup(optarg);
+				if (!test->bind_address) {
+					PRINT_ERR("failed to allocate memory for bind_address");
+					exit(ERROR_ARGS);
+				}
 			} else {
-				if (optind < argc && NULL != argv[optind] && '\0' != argv[optind][0] && '-' != argv[optind][0])
-					test->bind_address = argv[optind++];
+				if (optind < argc && NULL != argv[optind] && '\0' != argv[optind][0] && '-' != argv[optind][0]) {
+					free(test->bind_address);
+					test->bind_address = strdup(argv[optind++]);
+					if (!test->bind_address) {
+						PRINT_ERR("failed to allocate memory for bind_address");
+						exit(ERROR_ARGS);
+					}
+				}
 			}
 			break;
 
@@ -479,10 +497,10 @@ int parse_arguments(struct ntttcp_test *test, int argc, char **argv)
 			test->server_ports = atoi(optarg);
 			break;
 
-                case 'a':	
-                        test->client_address     = optarg;
-                        test->use_client_address = true;
-                        break;
+		case 'a':
+			test->client_address = optarg;
+			test->use_client_address = true;
+			break;
 
 		case 'n':
 			test->threads_per_server_port = atoi(optarg);

--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -326,6 +326,7 @@ int ntttcp_server_listen(struct ntttcp_stream_server *ss)
 	ASPRINTF(&port_str, "%d", ss->server_port);
 	if (getaddrinfo(ss->bind_address, port_str, &hints, &serv_info) != 0) {
 		PRINT_ERR("cannot get address info for receiver");
+		free(port_str);
 		return -1;
 	}
 	free(port_str);
@@ -349,17 +350,17 @@ int ntttcp_server_listen(struct ntttcp_stream_server *ss)
 		if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, (char *)&opt, sizeof(opt)) < 0) {
 			ASPRINTF(&log, "cannot set socket options: %d", sockfd);
 			PRINT_ERR_FREE(log);
+			close(sockfd);
 			freeaddrinfo(serv_info);
 			free(local_addr_str);
-			close(sockfd);
 			return -1;
 		}
 		if (set_socket_non_blocking(sockfd) == -1) {
 			ASPRINTF(&log, "cannot set socket as non-blocking: %d", sockfd);
 			PRINT_ERR_FREE(log);
+			close(sockfd);
 			freeaddrinfo(serv_info);
 			free(local_addr_str);
-			close(sockfd);
 			return -1;
 		}
 
@@ -369,9 +370,13 @@ int ntttcp_server_listen(struct ntttcp_stream_server *ss)
 				local_addr_str = retrive_ip_address_str((struct sockaddr_storage *)p->ai_addr, local_addr_str, ip_addr_max_size),
 				sockfd, i);
 
-			if (i == -1) /* append more info to log */
-				ASPRINTF(&log, "%s. errcode = %d", log, errno);
+			if (i == -1) { /* append more info to log */
+				char *old_log = log;
+				ASPRINTF(&log, "%s. errcode = %d", old_log, errno);
+				free(old_log);
+			}
 			PRINT_DBG_FREE(log);
+			close(sockfd);
 			continue;
 		} else {
 			break; /* connected */
@@ -382,7 +387,6 @@ int ntttcp_server_listen(struct ntttcp_stream_server *ss)
 	if (p == NULL) {
 		ASPRINTF(&log, "cannot bind the socket on address: %s", ss->bind_address);
 		PRINT_ERR_FREE(log);
-		close(sockfd);
 		return -1;
 	}
 
@@ -495,11 +499,15 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 					if (set_socket_non_blocking(newfd) == -1) {
 						ASPRINTF(&log, "cannot set the new socket as non-blocking: %d error [%s]", newfd, strerror(errno));
 						PRINT_DBG_FREE(log);
+						close(newfd);
+						continue;
 					}
 
 					if (ss->tcp_nodelay && set_socket_tcp_nodelay(newfd) == -1) {
 						ASPRINTF(&log, "cannot set the TCP_NODELAY for socket [%d] error [%s]", newfd, strerror(errno));
 						PRINT_DBG_FREE(log);
+						close(newfd);
+						continue;
 					}
 
 					local_addr_size = sizeof(local_addr);
@@ -522,8 +530,11 @@ int ntttcp_server_epoll(struct ntttcp_stream_server *ss)
 
 					event.data.fd = newfd;
 					event.events = EPOLLIN;
-					if (epoll_ctl(efd, EPOLL_CTL_ADD, newfd, &event) != 0)
+					if (epoll_ctl(efd, EPOLL_CTL_ADD, newfd, &event) != 0) {
 						PRINT_ERR("epoll_ctl failed");
+						close(newfd);
+						continue;
+					}
 
 					/* if there is no synch thread, if any new connection coming, indicates ss started */
 					if (ss->no_synch)
@@ -635,11 +646,15 @@ int ntttcp_server_select(struct ntttcp_stream_server *ss)
 				if (set_socket_non_blocking(newfd) == -1) {
 					ASPRINTF(&log, "cannot set the new socket as non-blocking: %d error [%s]", newfd, strerror(errno));
 					PRINT_DBG_FREE(log);
+					close(newfd);
+					continue;
 				}
                                 
 				if (ss->tcp_nodelay && set_socket_tcp_nodelay(newfd) == -1) {
 					ASPRINTF(&log, "cannot set the TCP_NODELAY for socket [%d] error [%s]", newfd, strerror(errno));
 					PRINT_DBG_FREE(log);
+					close(newfd);
+					continue;
 				}
 
 				FD_SET(newfd, &ss->read_set); /* add the new one to read_set */

--- a/src/tcpstream.c
+++ b/src/tcpstream.c
@@ -370,12 +370,17 @@ int ntttcp_server_listen(struct ntttcp_stream_server *ss)
 				local_addr_str = retrive_ip_address_str((struct sockaddr_storage *)p->ai_addr, local_addr_str, ip_addr_max_size),
 				sockfd, i);
 
-			if (i == -1) { /* append more info to log */
+			if (i == -1 && log != NULL) { /* append more info to log */
 				char *old_log = log;
 				ASPRINTF(&log, "%s. errcode = %d", old_log, errno);
-				free(old_log);
+				if (log != NULL) {
+					free(old_log);
+				} else {
+					log = old_log; /* restore original message if second ASPRINTF failed */
+				}
 			}
-			PRINT_DBG_FREE(log);
+			if (log != NULL)
+				PRINT_DBG_FREE(log);
 			close(sockfd);
 			continue;
 		} else {

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -55,7 +55,7 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
                 /* get interface name using the interface ip address */
                 if (get_interface_name_by_ip(sc->client_address, sc->domain, if_name, IFNAMSIZ) != 0) {
                         ASPRINTF(&log, "failed to get interface name by address [%s]", sc->client_address);
-                        PRINT_ERR(log);
+                        PRINT_ERR_FREE(log);
                         return NULL;
                 }
         }
@@ -63,13 +63,13 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
         /* update client information */
         if (ntttcp_update_client_info(&client_addr, sc) < 0) {
                 ASPRINTF(&log, "failed to update udp client info [%s]", sc->client_address);
-                PRINT_ERR(log);
+                PRINT_ERR_FREE(log);
                 return NULL;
         }
 
 	for (i = 0; i < sc->num_connections; i++) {
 
-		if ((sockfd = socket(sc->domain, sc->domain, 0)) < 0) {
+		if ((sockfd = socket(sc->domain, UDP, 0)) < 0) {
 			PRINT_ERR("cannot create socket endpoint");
 			sockfds[i] = -1;
 			continue;
@@ -88,7 +88,7 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
                 if (ret != 0) {
                         ASPRINTF(&log, "failed to do udp socket bind : socket domain [%d] client_port [%d] errno [%d]", 
                         sc->domain, client_port, errno);
-                        PRINT_ERR(log);
+                        PRINT_ERR_FREE(log);
                         close(sockfd);
                         sockfds[i] = -1;
                         continue;
@@ -100,7 +100,7 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
                         if (ret != NO_ERROR) {
                                 ASPRINTF(&log, "failed to do udp socket bind to device : socket domain [%d] client_port [%d] errno [%d] if_name [%s]", 
                                 sc->domain, client_port, errno, if_name);
-                                PRINT_ERR(log);
+                                PRINT_ERR_FREE(log);
                                 close(sockfd);
                                 sockfds[i] = -1;
                                 continue;
@@ -114,7 +114,7 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
 		if (connect(sockfd, &serv_addr, sa_size) == -1) {
                         ASPRINTF(&log,"failed to connect socket[%d] to remote: [%s:%d]. errno = %d.",
                                 sockfd, sc->bind_address, sc->server_port, errno);
-                        PRINT_ERR(log);
+                        PRINT_ERR_FREE(log);
                         close(sockfd);
                         sockfds[i] = -1;
                         continue;
@@ -248,9 +248,13 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 				"failed to bind the socket to local address: %s on socket: %d. return = %d",
 				local_addr_str = retrive_ip_address_str((struct sockaddr_storage *)p->ai_addr, local_addr_str, ip_addr_max_size), sockfd, ret);
 
-			if (ret == -1) /* append more info to log */
-				ASPRINTF(&log, "%s. errcode = %d", log, errno);
+			if (ret == -1) { /* append more info to log */
+				char *old_log = log;
+				ASPRINTF(&log, "%s. errcode = %d", old_log, errno);
+				free(old_log);
+			}
 			PRINT_DBG_FREE(log);
+			close(sockfd);
 			continue;
 		} else {
 			break; /* connected */
@@ -291,5 +295,7 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 		}
 	}
 
+	free(buffer);
+	close(sockfd);
 	return (void *)nbytes;
 }

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -195,7 +195,7 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 	char *log;
 
 	int ret = 0; /* hold function return value */
-	int sockfd = 0; /* socket file descriptor */
+	int sockfd = -1; /* socket file descriptor */
 	char *buffer; /* receive buffer */
 	char *local_addr_str; /* used to get local ip address */
 	int ip_addr_max_size; /* used to get local ip address */

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -249,12 +249,17 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 				"failed to bind the socket to local address: %s on socket: %d. return = %d",
 				local_addr_str = retrive_ip_address_str((struct sockaddr_storage *)p->ai_addr, local_addr_str, ip_addr_max_size), sockfd, ret);
 
-			if (ret == -1) { /* append more info to log */
+			if (ret == -1 && log != NULL) { /* append more info to log */
 				char *old_log = log;
 				ASPRINTF(&log, "%s. errcode = %d", old_log, errno);
-				free(old_log);
+				if (log != NULL) {
+					free(old_log);
+				} else {
+					log = old_log; /* restore original message if second ASPRINTF failed */
+				}
 			}
-			PRINT_DBG_FREE(log);
+			if (log != NULL)
+				PRINT_DBG_FREE(log);
 			close(sockfd);
 			sockfd = -1;
 			continue;

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -214,6 +214,7 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 	ASPRINTF(&port_str, "%d", ss->server_port);
 	if (getaddrinfo(ss->bind_address, port_str, &hints, &serv_info) != 0) {
 		PRINT_ERR("cannot get address info for receiver");
+		free(port_str);
 		return 0;
 	}
 	free(port_str);
@@ -255,6 +256,7 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 			}
 			PRINT_DBG_FREE(log);
 			close(sockfd);
+			sockfd = -1;
 			continue;
 		} else {
 			break; /* connected */
@@ -265,7 +267,8 @@ void *run_ntttcp_receiver_udp4_stream(struct ntttcp_stream_server *ss)
 	if (p == NULL) {
 		ASPRINTF(&log, "cannot bind the socket on address: %s", ss->bind_address);
 		PRINT_ERR_FREE(log);
-		close(sockfd);
+		if (sockfd >= 0)
+			close(sockfd);
 		return 0;
 	}
 

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -273,5 +273,116 @@ class TestNtttcp:
         throughput = parse_result.get_throughput_Gbps()
         assert int(throughput) in range(throughput_limit_gbps - 1, throughput_limit_gbps + 1)
 
+    def test_udp_sender_socket_creation_regression(self) -> None:
+        """
+        Regression test for UDP sender socket creation and connection handling.
+        Tests run_ntttcp_sender_udp4_stream end-to-end with multiple connections
+        to ensure sockets are created, bound, and connected properly.
+
+        This test exercises:
+        - Socket creation loop in run_ntttcp_sender_udp4_stream
+        - Socket binding with proper error handling
+        - Connection establishment to receiver
+        - Data transfer with multiple UDP connections
+        - Proper cleanup of socket file descriptors
+        """
+        n_server_ports = 2
+        n_threads = 3
+        n_connections = 4
+        total_connections = n_server_ports * n_threads * n_connections
+
+        # Test UDP sender with multiple connections per thread
+        common_option = f"-u -P {n_server_ports}"
+        sender_option = f"-n {n_threads} -l {n_connections} -V"
+        receiver_cmd, sender_cmd = self.combine_command(
+            common_option=common_option,
+            sender_option=sender_option
+        )
+
+        result = self.run_test(receiver_cmd, sender_cmd)
+        parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+        # Verify all connections were created successfully
+        connections_created = parse_result.get_multi_threads_info()
+        assert connections_created == total_connections, \
+            f"Expected {total_connections} UDP connections, but only {connections_created} were created"
+
+        # Verify data was transferred (UDP should show some throughput)
+        throughput = parse_result.get_throughput_Gbps()
+        assert throughput > 0, "UDP sender should transfer data successfully"
+
+        # Verify no socket creation errors in output
+        assert "cannot create socket endpoint" not in result.sender_stdout, \
+            "Socket creation should succeed for all UDP connections"
+        assert "failed to connect socket" not in result.sender_stdout, \
+            "Socket connection should succeed for all UDP connections"
+
+        self.log.write_info(f"UDP sender regression test passed: {connections_created} connections, {throughput:.2f} Gbps")
+
+    def test_udp_sender_single_connection(self) -> None:
+        """
+        Test UDP sender with single connection to verify basic functionality.
+        This is a simpler test case to catch basic UDP sender issues.
+        """
+        common_option = "-u"
+        sender_option = "-V"
+        receiver_cmd, sender_cmd = self.combine_command(
+            common_option=common_option,
+            sender_option=sender_option
+        )
+
+        result = self.run_test(receiver_cmd, sender_cmd)
+        parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+        # Verify data transfer occurred
+        throughput = parse_result.get_throughput_Gbps()
+        assert throughput > 0, "UDP sender should transfer data with single connection"
+
+        # Verify no errors
+        assert "cannot create socket endpoint" not in result.sender_stdout
+        assert "failed to connect socket" not in result.sender_stdout
+
+        self.log.write_info(f"UDP single connection test passed: {throughput:.2f} Gbps")
+
+    def test_udp_sender_with_custom_port(self) -> None:
+        """
+        Test UDP sender with custom starting port to verify socket binding works correctly.
+        This exercises the client_port binding logic in run_ntttcp_sender_udp4_stream.
+        """
+        starting_port = 15000
+        n_server_ports = 2
+        n_threads = 2
+        n_connections = 3
+        total_connections = n_server_ports * n_threads * n_connections
+
+        common_option = f"-u -p {starting_port} -P {n_server_ports}"
+        sender_option = f"-n {n_threads} -l {n_connections} -V"
+        receiver_cmd, sender_cmd = self.combine_command(
+            common_option=common_option,
+            sender_option=sender_option
+        )
+
+        result = self.run_test(receiver_cmd, sender_cmd)
+        parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+        # Verify connections were created
+        connections_created = parse_result.get_multi_threads_info()
+        assert connections_created == total_connections, \
+            f"Expected {total_connections} UDP connections with custom port"
+
+        # Verify custom port appears in UDP stream messages
+        assert f"--> 127.0.0.1:{starting_port}" in result.sender_stdout, \
+            f"Expected UDP streams to connect to custom port {starting_port}"
+
+        # Verify data transfer
+        throughput = parse_result.get_throughput_Gbps()
+        assert throughput > 0, "UDP sender should transfer data with custom port"
+
+        # Verify no errors
+        assert "cannot create socket endpoint" not in result.sender_stdout
+        assert "failed to connect socket" not in result.sender_stdout
+
+        self.log.write_info(f"UDP custom port test passed: {connections_created} connections, {throughput:.2f} Gbps")
+
 if __name__ == "__main__":
     pytest.main()

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -384,5 +384,131 @@ class TestNtttcp:
 
         self.log.write_info(f"UDP custom port test passed: {connections_created} connections, {throughput:.2f} Gbps")
 
+    def test_udp_sender_high_connection_count_stress(self) -> None:
+        """
+        Stress test: Verify UDP sender handles very high connection counts correctly.
+
+        Tests with elevated connection count to stress the socket creation loop:
+        - Creates many simultaneous UDP connections
+        - Verifies all are handled without leaks
+        - Tests that continue logic works when some might fail
+        - Ensures proper cleanup of all sockets
+
+        This exercises:
+        - Socket creation loop robustness in udpstream.c
+        - Proper iteration through sockfds array
+        - Error recovery when socket creation might fail under load
+        - Memory management with many allocations
+        """
+        n_server_ports = 3
+        n_threads = 4
+        n_connections = 8  # Total: 96 connections
+        total_connections = n_server_ports * n_threads * n_connections
+
+        # Test with high connection count
+        common_option = f"-u -P {n_server_ports}"
+        sender_option = f"-n {n_threads} -l {n_connections} -V -t 3"
+        receiver_cmd, sender_cmd = self.combine_command(
+            common_option=common_option,
+            sender_option=sender_option
+        )
+
+        result = self.run_test(receiver_cmd, sender_cmd)
+        parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+        # Should create all requested connections without errors
+        connections_created = parse_result.get_multi_threads_info()
+        assert connections_created == total_connections, \
+            f"Expected {total_connections} connections under stress test, got {connections_created}"
+
+        # Verify no errors despite high load
+        assert "cannot create socket endpoint" not in result.sender_stdout, \
+            "Socket creation should succeed even with many connections"
+        assert "failed to connect socket" not in result.sender_stdout, \
+            "Socket connections should succeed even with many connections"
+
+        # Verify actual data transfer occurred (tests cleanup was proper)
+        throughput = parse_result.get_throughput_Gbps()
+        assert throughput > 0, "Should have throughput even under high connection stress"
+
+        self.log.write_info(f"Stress test passed: {connections_created} connections, {throughput:.2f} Gbps")
+
+    def test_udp_sender_connect_failure_handling(self) -> None:
+        """
+        Negative test: Verify UDP sender handles connection failures gracefully.
+
+        Tests error handling when receiver is not available:
+        - Attempts to connect to non-existent receiver
+        - Verifies proper error logging and cleanup
+        - Ensures no socket leaks on connect failure
+        - Confirms test exits gracefully with error
+
+        This exercises:
+        - udpstream.c connect error handling (lines 115-121)
+        - Socket cleanup: close(sockfd) + sockfds[i] = -1
+        - ASPRINTF + PRINT_ERR_FREE error logging
+        - Proper handling when all connections fail
+        """
+        # Use a port where no receiver is listening
+        unused_port = 55555
+        n_connections = 3
+
+        # Don't start receiver - sender should fail to connect
+        sender_cmd = f"ulimit -n 40960 && ./src/ntttcp -s{self.loopback_interface} -u -p {unused_port} -l {n_connections} -V -t 1 -Q"
+
+        # Sender should exit with error since no receiver
+        result = subprocess.run([sender_cmd], shell=True, capture_output=True, text=True, timeout=15)
+
+        # Verify error handling was executed (should mention sync failure since no receiver)
+        assert result.returncode != 0 or "failed to create sync socket" in result.stdout or "failed to connect" in result.stdout.lower(), \
+            "Expected connection failure when receiver not available"
+
+        self.log.write_info(f"Connect failure test: verified graceful handling of missing receiver (exit code: {result.returncode})")
+
+    def test_udp_sender_rapid_succession_cleanup(self) -> None:
+        """
+        Stress test: Verify UDP sender properly cleans up resources in rapid succession.
+
+        Runs multiple short UDP tests back-to-back to verify:
+        - Sockets are properly closed after each test
+        - No file descriptor leaks accumulate
+        - Error paths clean up correctly
+        - Resources are released for reuse
+
+        This validates the cleanup paths exercised in PR:
+        - Proper close() of all sockfds
+        - Memory cleanup in normal exit path
+        - No resource accumulation across multiple test runs
+        """
+        n_ports = 1
+        n_threads = 1
+        n_connections = 5
+        total_connections = n_ports * n_threads * n_connections
+        test_iterations = 3
+
+        for iteration in range(test_iterations):
+            common_option = f"-u -P {n_ports}"
+            sender_option = f"-n {n_threads} -l {n_connections} -V -t 1"
+            receiver_cmd, sender_cmd = self.combine_command(
+                common_option=common_option,
+                sender_option=sender_option
+            )
+
+            result = self.run_test(receiver_cmd, sender_cmd)
+            parse_result = ntttcp_output.NtttcpOutput(result.receiver_stdout, result.sender_stdout)
+
+            # Each iteration should succeed independently
+            connections_created = parse_result.get_multi_threads_info()
+            assert connections_created == total_connections, \
+                f"Iteration {iteration+1}: Expected {total_connections} connections, got {connections_created}"
+
+            throughput = parse_result.get_throughput_Gbps()
+            assert throughput > 0, f"Iteration {iteration+1}: Should have throughput"
+
+            # Small delay between iterations to ensure cleanup completes
+            time.sleep(0.5)
+
+        self.log.write_info(f"Rapid succession test passed: {test_iterations} iterations completed successfully")
+
 if __name__ == "__main__":
     pytest.main()

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -371,7 +371,7 @@ class TestNtttcp:
             f"Expected {total_connections} UDP connections with custom port"
 
         # Verify custom port appears in UDP stream messages
-        assert f"--> 127.0.0.1:{starting_port}" in result.sender_stdout, \
+        assert f"--> {self.loopback_interface}:{starting_port}" in result.sender_stdout, \
             f"Expected UDP streams to connect to custom port {starting_port}"
 
         # Verify data transfer


### PR DESCRIPTION
# Fix: Memory Leaks and Resource Management (17 Issues)

## Overview

This PR was initiated to fix issue #108. 

However, this PR now fixes **17 memory and resource management bugs** discovered through systematic code review, AddressSanitizer (ASAN/LSan), and Valgrind analysis of the ntttcp-for-linux codebase. The bugs fall into three categories:

- **Heap memory leaks** — allocated memory never freed (`malloc`, `strdup`, `ASPRINTF`)
- **File descriptor leaks** — sockets and file handles not closed in error paths or at function exit
- **Logic error** — wrong constant passed to `socket()` in UDP sender

All issues were found on the **unfixed codebase**. Evidence sections below reproduce each leak using the commands shown. Later, after fixing the bugs, AddressSanitizer and Valgrind tests were executed again on the **fixed codebase** to check if the leaks were fixed.

### Test Setup

**ASAN build:**
```bash
make CFLAGS="-g -O1 -fsanitize=address,leak -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address,leak"
export ASAN_OPTIONS="detect_leaks=1:leak_check_at_exit=1:exitcode=23"
# Exit code 23 = leaks detected; 0 = clean
```

**Valgrind build:**
```bash
make CFLAGS="-g -O0 -fno-omit-frame-pointer"
VG="valgrind"
VG_OPTS="--track-fds=yes --leak-check=full --show-leak-kinds=all --num-callers=12 --error-exitcode=1"
```

---

## Files Changed

| File | Issues Fixed |
|------|-------------|
| `src/parameter.c` | Bug1 — strdup leak in `process_mappings()` |
| `src/main.c` | Bug2 — sync socket not closed in sender error paths |
| `src/udpstream.c` | Bug3, Bug4, Bug5, Bug6, Bug15, Bug16 — log leaks, buffer/socket leak, socket type bug, bind loop FD leak |
| `src/endpointsync.c` | Bug7, Bug8, Bug13 — redundant alloc, double malloc, missing freeaddrinfo, FD leaks |
| `src/tcpstream.c` | Bug9, Bug10, Bug11, Bug12 — FD leaks, log realloc leak in bind and accept error paths |
| `src/ntttcp.c` | Bug14 — threads result array never freed |
| `src/oscounter.c` | Bug17 — `/proc/interrupts` FD not closed on early return |

---

## Issues Fixed

---

### Bug1 · `parameter.c` — `strdup` result leaked in `process_mappings()`

**How found:** ASAN, static analysis  
**Location:** `parameter.c:204`

**Root cause:** `process_mappings()` calls `strdup(test->mapping)` and stores the result in `element`. `strsep()` then advances the `element` pointer. When an invalid CPU ID is detected, the function returns `ERROR_ARGS` without freeing the original allocation.

```c
// BEFORE (buggy)
element = strdup(test->mapping);   // line 204 — original pointer saved
...
strsep(&element, ",");             // element pointer advances
...
if (cpu_n >= MAX_CPU_COUNT)
    return ERROR_ARGS;             // BUG: original strdup allocation never freed
```

**Fix:** Save the original pointer on entry and `free()` it in every return path.

**Evidence (ASAN):**
```bash
./ntttcp -r -m "4,9999,127.0.0.1"
# Exit 23
```
```
Direct leak of 17 byte(s) in 1 object(s) allocated from:
    #0 in strdup          asan_interceptors.cpp:578
    #1 in process_mappings parameter.c:204
    #2 in parse_arguments  parameter.c:461
    #3 in main             main.c:337

SUMMARY: AddressSanitizer: 33 byte(s) leaked in 2 allocation(s).
```

---

### Bug2 · `main.c` — sync socket not closed in `run_ntttcp_sender()` error paths

**How found:** Static analysis, `valgrind --track-fds=yes`  
**Location:** `main.c:38–47`

**Root cause:** `synch_socket` is opened at the start of `run_ntttcp_sender()` but is not closed before the `return ERROR_GENERAL` statements in the error paths at lines ~43 and ~47.

**Fix:** Added `close(tep->synch_socket)` before each `return ERROR_GENERAL` in the error paths.

**Evidence:** File descriptor leak confirmed with `valgrind --track-fds=yes ./ntttcp -s 127.0.0.1`. LSAN does not track FD leaks.

---

### Bug3 · `udpstream.c` — `ASPRINTF` log leaked on early return in `run_ntttcp_sender_udp4_stream()`

**How found:** ASAN, static analysis  
**Location:** `udpstream.c:60, 68`

**Root cause:** When `get_interface_name_by_ip()` or `update_client_info()` fails, the function allocates a log string with `ASPRINTF(&log, ...)` and then calls `PRINT_ERR(log)`. The `PRINT_ERR` macro prints but does not free `log`.

```c
// BEFORE (buggy)
ASPRINTF(&log, "failed to get interface ...");
PRINT_ERR(log);   // BUG: log is printed but never freed
return NULL;
```

**Fix:** Changed to `PRINT_ERR_FREE(log)`, which prints and frees the string.

**Evidence (ASAN):**
```bash
./ntttcp -s 127.0.0.1 -u -a 192.0.2.1 -N -t 1 -P 1
# Exit 23
```
```
Direct leak of 208 byte(s) in 4 object(s) allocated from:
    #0 in malloc                         asan_malloc_linux.cpp:69
    #1 in asprintf                       stdio2.h:137
    #2 in run_ntttcp_sender_udp4_stream  udpstream.c:57
    #3 in run_ntttcp_sender_udp_stream   udpstream.c:16

SUMMARY: AddressSanitizer: 208 byte(s) leaked in 4 allocation(s).
```
(208 bytes = ~52-byte log string × 4 sender threads)

---

### Bug4 · `udpstream.c` — `ASPRINTF` log leaked in socket error paths

**How found:** Static analysis  
**Location:** `udpstream.c:89, 99, 119`

**Root cause:** Same `ASPRINTF` + `PRINT_ERR(log)` pattern as issue Bug3. Triggered when `socket()`, `setsockopt()`, or `connect()` fails.

**Fix:** Changed all three occurrences from `PRINT_ERR(log)` to `PRINT_ERR_FREE(log)`.

---

### Bug5 · `udpstream.c` — log string leaked via `ASPRINTF` overwrite in receiver bind path

**How found:** Static analysis  
**Location:** `udpstream.c:252`

**Root cause:** The pattern `ASPRINTF(&log, "%s. errcode=%d", log, errno)` overwrites the `log` pointer with a new allocation without freeing the old one first. The original allocation at `log` is lost.

```c
// BEFORE (buggy)
ASPRINTF(&log, "bind error ...");
if (ret == -1)
    ASPRINTF(&log, "%s. errcode=%d", log, errno);  // BUG: old log ptr overwritten
```

**Fix:**
```c
char *old_log = log;
ASPRINTF(&log, "%s. errcode=%d", old_log, errno);
free(old_log);
```

---

### Bug6 · `udpstream.c` — receive buffer and socket not freed on function exit

**How found:** ASAN  
**Location:** `udpstream.c:268` (buffer allocation), end of `run_ntttcp_receiver_udp4_stream()`

**Root cause:** `buffer = malloc(udp_recv_size)` (65,536 bytes) is allocated for the receive loop but never freed before the function returns. `sockfd` is also not closed.

**Fix:** Added `free(buffer)` and `close(sockfd)` before the function returns.

**Evidence (ASAN):**
```bash
./ntttcp -r 127.0.0.1 -t 3 -P 1 -u -N
# Exit 23
```
```
Direct leak of 65536 byte(s) in 1 object(s) allocated from:
    #0 in malloc                           asan_malloc_linux.cpp:69
    #1 in run_ntttcp_receiver_udp4_stream  udpstream.c:268
    #2 in run_ntttcp_receiver_udp_stream   udpstream.c:183

SUMMARY: AddressSanitizer: 65544 byte(s) leaked in 2 allocation(s).
```
(65,544 = 65,536-byte buffer + 8-byte threads array from issue Bug14)

---

### Bug7 · `endpointsync.c` — redundant `ip_address_max_size` assignment removed

**How found:** Static analysis  
**Location:** `endpointsync.c:45`

**Root cause:** `ip_address_max_size` was assigned twice — the second assignment was redundant and had no effect. Not a leak, but a code clarity fix.

**Fix:** Removed the duplicate assignment.

---

### Bug8 · `endpointsync.c` — double malloc of `ip_address_str` + missing `freeaddrinfo()`

**How found:** Valgrind, static analysis  
**Location:** `endpointsync.c:327, 336` in `create_receiver_sync_socket()`

**Root cause:**
1. `ip_address_str` is allocated with `malloc(INET_ADDRSTRLEN)` at line 327, then immediately allocated again at line 336. The first allocation is overwritten and leaked (16 bytes).
2. `getaddrinfo()` result (`serv_info`) allocated at line 320 is never freed with `freeaddrinfo()` (64 bytes).

**Fix:** Removed the duplicate `ip_address_str` allocation; added `freeaddrinfo(serv_info)` after use.

**Evidence (Valgrind):**
```bash
$VG $VG_OPTS ./ntttcp -r 127.0.0.1 -t 5 -P 1 -n 1
```
```
==34545== 16 bytes in 1 blocks are definitely lost
==34545==    by create_receiver_sync_socket (endpointsync.c:327)

==34545== 64 bytes in 1 blocks are definitely lost
==34545==    by getaddrinfo (getaddrinfo.c:2391)
==34545==    by create_receiver_sync_socket (endpointsync.c:320)

LEAK SUMMARY: definitely lost: 96 bytes in 3 blocks
```

---

### Bug9 · `tcpstream.c` — `sockfd` not closed in bind-retry loop in `ntttcp_server_listen()`

**How found:** Static analysis, `valgrind --track-fds=yes`  
**Location:** `tcpstream.c:375`

**Root cause:** `ntttcp_server_listen()` iterates through `getaddrinfo()` results trying to bind. A new `sockfd` is opened on each iteration via `socket()`. When `bind()` fails the loop calls `continue` without closing `sockfd` first.

**Fix:** Added `close(sockfd)` before `continue` in the bind-failure path.

---

### Bug10 · `tcpstream.c` — log string leaked via `ASPRINTF` overwrite in `ntttcp_server_listen()`

**How found:** Valgrind, static analysis  
**Location:** `tcpstream.c:367`

**Root cause:** Same overwrite pattern as issue Bug5. When `bind()` fails, the function builds an error string by overwriting `log` with `ASPRINTF(&log, "%s. errcode=%d", log, errno)`, losing the original pointer.

**Fix:** Same pattern — save the old pointer before overwriting and free it afterwards.

**Evidence (Valgrind):**
```bash
# Run when port 5001 is already occupied
$VG $VG_OPTS ./ntttcp -r 127.0.0.1 -t 2 -P 1 -n 1 -N
```
```
==37431== 80 bytes in 1 blocks are definitely lost
==37431==    by asprintf   (asprintf.c:31)
==37431==    by ntttcp_server_listen (tcpstream.c:367)

LEAK SUMMARY: definitely lost: 80 bytes in 1 blocks
```

---

### Bug11 · `tcpstream.c` — `newfd` not closed in `ntttcp_server_epoll()` error paths

**How found:** Static analysis, `valgrind --track-fds=yes`  
**Location:** `tcpstream.c:500–511, 532`

**Root cause:** `accept()` returns `newfd`. If `set_socket_non_blocking()`, `set_socket_tcp_nodelay()`, or `epoll_ctl()` subsequently fails, the code logs an error and `continue`s without calling `close(newfd)`. Each such failure leaks a socket descriptor.

**Fix:** Added `close(newfd)` before each `continue` in the failure paths.

**Evidence (ASAN — epoll receiver, no-sync):**
```bash
export ASAN_OPTIONS="detect_leaks=1:leak_check_at_exit=1:exitcode=23"
./ntttcp -r 127.0.0.1 -t 5 -P 1 -n 1 -e -N -p 5700 >/tmp/epoll_recv.txt 2>&1 &
RPID=$!; sleep 2
./ntttcp -s 127.0.0.1 -t 5 -P 1 -n 1 -N -p 5700 >/tmp/epoll_send.txt 2>&1
wait $RPID
```
Receiver ASAN output shows only the threads array leak (Bug14) — no new heap leaks. The `newfd` FD leak is not detectable by LSAN; use `valgrind --track-fds=yes` to confirm.

---

### Bug12 · `tcpstream.c` — `newfd` not closed in `ntttcp_server_select()` error paths

**How found:** Valgrind, static analysis  
**Location:** `tcpstream.c:647–656`

**Root cause:** Same pattern as issue Bug11, in the `select()`-based path. `newfd` from `accept()` is not closed when `set_socket_non_blocking()` or `set_socket_tcp_nodelay()` fails.

**Fix:** Added `close(newfd)` before each `continue` in the failure paths.

**Evidence (Valgrind):**
```bash
$VG $VG_OPTS ./ntttcp -r 127.0.0.1 -t 5 -P 1 -n 1
```
```
==34545== FILE DESCRIPTORS: 6 open (3 std) at exit.
==34545== Open AF_INET socket 7: 127.0.0.1:5001 <-> 127.0.0.1:47659
==34545==    by accept         (accept.c:26)
==34545==    by ntttcp_server_select (tcpstream.c:629)
```

---

### Bug13 · `endpointsync.c` — `newfd` not closed in sync socket accept handling

**How found:** Static analysis  
**Location:** `endpointsync.c:399–407` in `create_receiver_sync_socket()`

**Root cause:** `newfd` from `accept()` in the sync connection handler is not closed when `set_socket_non_blocking()` or `epoll_ctl()` fails, leaking the descriptor.

**Fix:** Added `close(newfd)` before each `continue` in the failure paths.

---

### Bug14 · `ntttcp.c` — `e->results->threads` array pointer never freed

**How found:** ASAN, Valgrind  
**Location:** `ntttcp.c:160` (alloc), `ntttcp.c:229` (teardown)

**Root cause:** `new_ntttcp_test_endpoint()` allocates an array of `ntttcp_test_endpoint_thread_result*` pointers at line 160. `free_ntttcp_test_endpoint_and_test()` correctly frees each individual element in the array, but never frees the array itself before freeing `e->results`.

```c
// BEFORE (buggy): only element contents freed, not the array
for (i = 0; i < total_threads; i++)
    free(e->results->threads[i]);
// BUG: free(e->results->threads) never called
free(e->results);
```

**Fix:** Added `free(e->results->threads)` after the loop, before `free(e->results)`.

**Evidence (ASAN) — present in every test run:**
```bash
./ntttcp -s 127.0.0.1 -t 3 -P 2 -n 1   # TCP sender, 2 ports × 1 thread = 16 bytes
```
```
Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 in malloc                   asan_malloc_linux.cpp:69
    #1 in new_ntttcp_test_endpoint ntttcp.c:160
    #2 in main                     main.c:381

SUMMARY: AddressSanitizer: 16 byte(s) leaked in 1 allocation(s).
```

**Evidence (Valgrind) — all four roles:**

| Role | Leak | Command |
|------|------|---------|
| TCP sender (1P×1T) | 8 bytes | `./ntttcp -s 127.0.0.1 -t 5 -P 1 -n 1` |
| TCP receiver (1P) | 16 bytes | `./ntttcp -r 127.0.0.1 -t 5 -P 1 -n 1` |
| UDP sender (1P) | 32 bytes | `./ntttcp -s 127.0.0.1 -t 5 -P 1 -u -N` |
| UDP receiver (1P, -N) | 8 bytes | `./ntttcp -r 127.0.0.1 -t 5 -P 1 -u -N` |

Leak size = `sizeof(void *) × total_threads` (8 bytes per pointer on 64-bit).

---

### Bug15 · `udpstream.c` — wrong `socket()` type parameter in UDP sender

**How found:** Static analysis  
**Location:** `udpstream.c:72` in `run_ntttcp_sender_udp4_stream()`

**Root cause:** The `socket()` system call receives `sc->domain` (the address family, e.g. `AF_INET = 2`) as both the first and second argument. The second argument should be the socket type (`SOCK_DGRAM`).

```c
// BEFORE (buggy)
sockfd = socket(sc->domain, sc->domain, 0);  // sc->domain used as socket type — wrong
```

On Linux `AF_INET == SOCK_DGRAM == 2`, so IPv4 UDP works by coincidence. With IPv6 (`AF_INET6 = 10`), this becomes `socket(AF_INET6, 10, 0)` = `socket(AF_INET6, SOCK_RAW, 0)`, silently creating a raw socket instead of a datagram socket.

**Fix:**
```c
sockfd = socket(sc->domain, UDP, 0);   // UDP is defined as SOCK_DGRAM
```

---

### Bug16 · `udpstream.c` — `sockfd` not closed in bind-retry loop in UDP receiver

**How found:** Static analysis, `valgrind --track-fds=yes`  
**Location:** `udpstream.c:247` in `run_ntttcp_receiver_udp4_stream()`

**Root cause:** The function iterates through `getaddrinfo()` results trying to bind. A new socket is created on each iteration. When `bind()` fails the loop calls `continue` without closing `sockfd` first.

```c
// BEFORE (buggy)
if (bind(sockfd, ...) < 0) {
    ...
    continue;   // BUG: sockfd not closed before retrying
}
```

**Fix:** Added `close(sockfd)` before `continue`.

**Evidence:** Confirmed by `valgrind --track-fds=yes ./ntttcp -r -u`. Valgrind reports the successfully-bound socket as open at exit (since `close(sockfd)` is also missing at function return — fixed by issue Bug6).

---

### Bug17 · `oscounter.c` — `/proc/interrupts` file descriptor not closed on early return

**How found:** Valgrind (new bug discovered during testing)  
**Location:** `oscounter.c:85` in `get_interrupts_from_proc_by_dev()`

**Root cause:** The function opens `/proc/interrupts` with `fopen()` at line 85, then checks whether `dev_name` is empty. The default value of `show_dev_interrupts` is `""` (see `ntttcp.c:53`), so this early-return path is taken on every normal test execution. The `fclose()` at the end of the function is never reached.

```c
FILE *file = fopen(PROC_FILE_INTERRUPTS, "r");   // FD opened
if (!strcmp(dev_name, ""))
    return 0;   // BUG: fclose(file) never called; FD + 472-byte FILE buffer leaked
```

`run_ntttcp_throughput_management()` calls this function **twice** (lines 161 and 194), so **2 FDs and 944 bytes** are leaked on every test run by both sender and receiver.

**Fix:**
```c
if (!strcmp(dev_name, "")) {
    fclose(file);   // close before early return
    return 0;
}
```

**Evidence (Valgrind — TCP sender, default flags):**
```bash
$VG $VG_OPTS ./ntttcp -s 127.0.0.1 -t 5 -P 1 -n 1
```
```
FILE DESCRIPTORS: 5 open (3 std) at exit.

Open file descriptor 5: /proc/interrupts
   by fopen@@GLIBC_2.2.5 (iofopen.c:86)
   by get_interrupts_from_proc_by_dev (oscounter.c:85)
   by run_ntttcp_throughput_management (throughputmanagement.c:161)

Open file descriptor 4: /proc/interrupts
   by fopen@@GLIBC_2.2.5 (iofopen.c:86)
   by get_interrupts_from_proc_by_dev (oscounter.c:85)
   by run_ntttcp_throughput_management (throughputmanagement.c:194)

472 bytes in 1 blocks are still reachable
   by fopen@@GLIBC_2.2.5 (iofopen.c:86)
   by get_interrupts_from_proc_by_dev (oscounter.c:85)
   by run_ntttcp_throughput_management (throughputmanagement.c:161)

472 bytes in 1 blocks are still reachable
   by fopen@@GLIBC_2.2.5 (iofopen.c:86)
   by get_interrupts_from_proc_by_dev (oscounter.c:85)
   by run_ntttcp_throughput_management (throughputmanagement.c:194)

LEAK SUMMARY: still reachable: 944 bytes in 2 blocks
ERROR SUMMARY: 3 errors from 3 contexts
```
Confirmed in all four roles: TCP sender, TCP receiver, UDP sender, UDP receiver.  
When `--show-dev-interrupts` is given a non-empty device name, the FDs are closed correctly and no leak appears.

---

## Detection Methods Summary

| Method | Bugs Found | Notes |
|--------|-----------|-------|
| ASAN / LSan | Bug1, Bug3, Bug6, Bug10, Bug14 (heap) | Cannot detect FD leaks |
| Valgrind `--leak-check=full` | Bug8, Bug10, Bug14, Bug17 (heap+FILE*) | |
| Valgrind `--track-fds=yes` | Bug2, Bug9, Bug11, Bug12, Bug13, Bug16 (FD) | Detects FD leaks |
| Static analysis | All 17 | Used to confirm and find remaining issues |

---

## How to Verify After This PR

```bash
make CFLAGS="-g -O1 -fsanitize=address,leak -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address,leak"
export ASAN_OPTIONS="detect_leaks=1:leak_check_at_exit=1:exitcode=23"

# TCP test (receiver + sender, no-sync for clean exit)
./ntttcp -r 127.0.0.1 -t 5 -P 2 -n 1 -N >/tmp/recv.txt 2>&1 &
RPID=$!; sleep 1
./ntttcp -s 127.0.0.1 -t 5 -P 2 -n 1 -N; echo "SENDER=$?"
wait $RPID; echo "RECV=$?"
# Expected: both exit 0 (no leaks)

# UDP test
./ntttcp -r 127.0.0.1 -t 5 -P 1 -u -N; echo "UDP_RECV=$?"
# Expected: exit 0
```

---

## Post-Fix Verification Results

All tests run on the fixed codebase. ASAN build + `ASAN_OPTIONS="detect_leaks=1:leak_check_at_exit=1:exitcode=23"`.

### ASAN Results

**TCP sender (no-sync) — exit 0, no leaks:**
```
$ ./ntttcp -s 127.0.0.1 -t 5 -P 1 -n 1 -N; echo "TCP_SENDER=$?"
TCP_SENDER=0
```

**UDP sender + receiver (no-sync) — both exit 0:**
```
$ ./ntttcp -s 127.0.0.1 -t 5 -P 1 -u -N; echo "UDP_SENDER=$?"
UDP_SENDER=0

$ ./ntttcp -r 127.0.0.1 -t 5 -P 1 -u -N; echo "UDP_RECV=$?"
UDP_RECV=0
```

**1 `process_mappings` strdup — no longer leaks (was exit 23):**
```
$ ./ntttcp -r -m "4,9999,127.0.0.1"; echo "EXIT=$?"
07:48:12 ERR : process_mappings: cpu specified is not in allowed scope
EXIT=1
# No ASAN ERROR output — previously: "SUMMARY: AddressSanitizer: 33 byte(s) leaked"
```

**Bug3 UDP bogus interface log leak — no longer leaks (was exit 23):**
```
$ ./ntttcp -s 127.0.0.1 -u -a 192.0.2.1 -N -t 2 -P 1 -n 1; echo "EXIT=$?"
07:51:09 ERR : failed to get interface name by address [192.0.2.1]
EXIT=1
# No ASAN ERROR output — previously: "SUMMARY: AddressSanitizer: 208 byte(s) leaked"
```

---

### Valgrind Results

Build: `make CFLAGS="-g -O0 -fno-omit-frame-pointer"`  
Flags: `--track-fds=yes --leak-check=full --show-leak-kinds=all --error-exitcode=1`

**UDP sender — clean (previously: threads array + socket FD leaks):**
```
==60442== FILE DESCRIPTORS: 3 open (3 std) at exit.
==60442== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**UDP receiver — clean (previously: 65,536-byte buffer + threads array leaked):**
```
==61244== FILE DESCRIPTORS: 3 open (3 std) at exit.
==61244== All heap blocks were freed -- no leaks are possible
==61244== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

**TCP sender — clean (previously: Bug17 `/proc/interrupts` FDs open, 944 bytes reachable):**
```
==60338== FILE DESCRIPTORS: 3 open (3 std) at exit.
==60338== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Previously (unfixed TCP sender, Bug17):
```
==XXXXX== FILE DESCRIPTORS: 5 open (3 std) at exit.
==XXXXX== Open file descriptor 5: /proc/interrupts
==XXXXX== Open file descriptor 4: /proc/interrupts
==XXXXX== LEAK SUMMARY: still reachable: 944 bytes in 2 blocks
==XXXXX== ERROR SUMMARY: 3 errors from 3 contexts
```
---

### Functional Tests Pass

<img width="1722" height="165" alt="image" src="https://github.com/user-attachments/assets/536827ba-db67-44c4-9028-d844a11bb393" />
