### PR TITLE
Convert builds to use musl libc for generic linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ jobs:
     name: build x86-64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
+      - uses: gerlero/apt-install@v1
+        with:
+          packages: musl musl-dev musl-tools
+      - uses: actions/checkout@v7
+      - run: cd src/ && CC="musl-gcc" cmake -DCMAKE_C_FLAGS="-static" . && make && ls -lh ntttcp && file ntttcp
 
       - name: Uploads binary file for x86-64
         uses: actions/upload-artifact@v4
@@ -23,7 +26,7 @@ jobs:
     name: build aarch64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: uraimo/run-on-arch-action@v2
         name: Build artifact
         id: build
@@ -31,8 +34,8 @@ jobs:
           arch: aarch64
           distro: ubuntu20.04
           run: |
-            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file
-            cd src/ && cmake . && make && ls -lh ntttcp && file ntttcp
+            apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file musl musl-dev musl-tools
+            cd src/ && CC="musl-gcc" cmake -DCMAKE_C_FLAGS="-static" . && make && ls -lh ntttcp && file ntttcp
 
       - name: Uploads binary file for aarch64
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: uraimo/run-on-arch-action@v2
+      - uses: uraimo/run-on-arch-action@v3
         name: Build artifact
         id: build
         with:
           arch: aarch64
-          distro: ubuntu20.04
+          distro: ubuntu_latest
           run: |
             apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential cmake file musl musl-dev musl-tools
             cd src/ && CC="musl-gcc" cmake -DCMAKE_C_FLAGS="-static" . && make && ls -lh ntttcp && file ntttcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: cd src/ && CC="musl-gcc" cmake -DCMAKE_C_FLAGS="-static" . && make && ls -lh ntttcp && file ntttcp
 
       - name: Uploads binary file for x86-64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ntttcp-x86_64
           path: src/ntttcp
@@ -38,7 +38,7 @@ jobs:
             cd src/ && CC="musl-gcc" cmake -DCMAKE_C_FLAGS="-static" . && make && ls -lh ntttcp && file ntttcp
 
       - name: Uploads binary file for aarch64
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ntttcp-aarch64
           path: src/ntttcp

--- a/src/udpstream.c
+++ b/src/udpstream.c
@@ -115,7 +115,7 @@ void *run_ntttcp_sender_udp4_stream(struct ntttcp_stream_client *sc)
 		if (sc->socket_fq_rate_limit_bytes != 0)
 			enable_fq_rate_limit(sc, sockfd);
 
-		if (connect(sockfd, &serv_addr, sa_size) == -1) {
+		if (connect(sockfd, (const struct sockaddr *)&serv_addr, sa_size) == -1) {
                         ASPRINTF(&log,"failed to connect socket[%d] to remote: [%s:%d]. errno = %d.",
                                 sockfd, sc->bind_address, sc->server_port, errno);
                         PRINT_ERR_FREE(log);


### PR DESCRIPTION
ntttcp is a small utility that can be readily used on any linux box, but with its current libc linkage it's intimately tied to the machine it's compiled on. Switching to musl, statically linked, means that the binary the CI toolchain produces is usable on any Linux machine with a halfway-recent kernel, even going back to 2.6.

This enables a lightweight, universally applicable release, and can address #96 